### PR TITLE
Improve node startup and handshake

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,76 @@
+use crate::protocol::{message::Message, payload::Version};
+
+use tokio::{
+    io,
+    net::{TcpListener, TcpStream},
+};
+
+use std::net::SocketAddr;
+
+/// Waits until an expression is true or times out.
+///
+/// Uses polling to cut down on time otherwise used by calling `sleep` in tests.
+#[macro_export]
+macro_rules! wait_until {
+    ($limit_secs: expr, $condition: expr $(, $sleep_millis: expr)?) => {
+        let now = std::time::Instant::now();
+        loop {
+            if $condition {
+                break;
+            }
+
+            // Default timout.
+            let sleep_millis = 10;
+            // Set if present in args.
+            $(let sleep_millis = $sleep_millis;)?
+            tokio::time::sleep(std::time::Duration::from_millis(sleep_millis)).await;
+            if now.elapsed() > std::time::Duration::from_secs($limit_secs) {
+                panic!("timed out!");
+            }
+        }
+    };
+}
+
+pub async fn handshake(listener: TcpListener) -> io::Result<TcpStream> {
+    let (mut peer_stream, addr) = listener.accept().await.unwrap();
+
+    let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
+    assert!(matches!(version, Message::Version(..)));
+
+    Message::Version(Version::new(addr, listener.local_addr().unwrap()))
+        .write_to_stream(&mut peer_stream)
+        .await
+        .unwrap();
+
+    let verack = Message::read_from_stream(&mut peer_stream).await.unwrap();
+    assert!(matches!(verack, Message::Verack));
+
+    Message::Verack
+        .write_to_stream(&mut peer_stream)
+        .await
+        .unwrap();
+
+    Ok(peer_stream)
+}
+
+pub async fn handshaken_peer(node_addr: SocketAddr) -> io::Result<TcpStream> {
+    let mut peer_stream = TcpStream::connect(node_addr).await?;
+
+    Message::Version(Version::new(node_addr, peer_stream.local_addr().unwrap()))
+        .write_to_stream(&mut peer_stream)
+        .await
+        .unwrap();
+
+    let version = Message::read_from_stream(&mut peer_stream).await?;
+    assert!(matches!(version, Message::Version(..)));
+
+    Message::Verack
+        .write_to_stream(&mut peer_stream)
+        .await
+        .unwrap();
+
+    let verack = Message::read_from_stream(&mut peer_stream).await?;
+    assert!(matches!(verack, Message::Verack));
+
+    Ok(peer_stream)
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -31,7 +31,11 @@ macro_rules! wait_until {
     };
 }
 
-pub async fn handshake(listener: TcpListener) -> io::Result<TcpStream> {
+/// Helper to respond to a handshake initiated by the node on connection to the supplied listener,
+/// returns the tcp stream.
+///
+/// Note, the listener's adddress must be set on the node as an initial peer.
+pub async fn respond_to_handshake(listener: TcpListener) -> io::Result<TcpStream> {
     let (mut peer_stream, addr) = listener.accept().await.unwrap();
 
     let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
@@ -53,7 +57,8 @@ pub async fn handshake(listener: TcpListener) -> io::Result<TcpStream> {
     Ok(peer_stream)
 }
 
-pub async fn handshaken_peer(node_addr: SocketAddr) -> io::Result<TcpStream> {
+/// Connects to the node at the given address, handshakes and returns the established stream.
+pub async fn initiate_handshake(node_addr: SocketAddr) -> io::Result<TcpStream> {
     let mut peer_stream = TcpStream::connect(node_addr).await?;
 
     Message::Version(Version::new(node_addr, peer_stream.local_addr().unwrap()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod helpers;
 pub mod protocol;
 pub mod setup;
 

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -101,10 +101,6 @@ impl Node {
             .expect("node failed to start");
 
         self.process = Some(process);
-
-        // In future maybe ping to check if ready? Maybe in include an explicit build step here as
-        // well?
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     }
 
     /// Stops the node instance.

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -10,16 +10,14 @@ use tokio::net::{TcpListener, TcpStream};
 
 #[tokio::test]
 async fn handshake_responder_side() {
-    // 1. Configure and run node.
-    // 2. Send a Version message to the node.
-    // 3. Expect a Version back and send Verack.
-    // 4. Expect Verack back.
+    // ZG-CONFORMANCE-001
 
     let (_zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
     node.start().await;
 
+    // Connect to the node and initiate handshake.
     let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
 
     Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()))
@@ -43,42 +41,42 @@ async fn handshake_responder_side() {
 
 #[tokio::test]
 async fn handshake_initiator_side() {
+    // ZG-CONFORMANCE-002
+
     let (zig, node_meta) = read_config_file();
 
     let listener = TcpListener::bind(zig.new_local_addr()).await.unwrap();
 
+    // Create a node and set the listener as an initial peer.
     let mut node = Node::new(node_meta);
     node.initial_peers(vec![listener.local_addr().unwrap().port()])
         .start()
         .await;
 
-    match listener.accept().await {
-        Ok((mut peer_stream, addr)) => {
-            let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
-            assert!(matches!(version, Message::Version(..)));
+    // Expect the node to initiate the handshake.
+    let (mut peer_stream, addr) = listener.accept().await.unwrap();
+    let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
+    assert!(matches!(version, Message::Version(..)));
 
-            Message::Version(Version::new(addr, listener.local_addr().unwrap()))
-                .write_to_stream(&mut peer_stream)
-                .await
-                .unwrap();
+    Message::Version(Version::new(addr, listener.local_addr().unwrap()))
+        .write_to_stream(&mut peer_stream)
+        .await
+        .unwrap();
 
-            let verack = Message::read_from_stream(&mut peer_stream).await.unwrap();
-            assert!(matches!(verack, Message::Verack));
+    let verack = Message::read_from_stream(&mut peer_stream).await.unwrap();
+    assert!(matches!(verack, Message::Verack));
 
-            Message::Verack
-                .write_to_stream(&mut peer_stream)
-                .await
-                .unwrap();
-        }
-        Err(e) => println!("couldn't get client: {:?}", e),
-    }
+    Message::Verack
+        .write_to_stream(&mut peer_stream)
+        .await
+        .unwrap();
 
     node.stop().await;
 }
 
 #[tokio::test]
 async fn reject_non_version_replies_to_version() {
-    // Conformance test 004.
+    // ZG-CONFORMANCE-004
     //
     // The node should reject non-Version messages in response to the initial Version it sent.
     //


### PR DESCRIPTION
This PR:
- introduces a `helpers` module to be used for general test heper code until we find a better structure for it,
- relies on peer connection to signal node startup completion (could be further improved, for now this is done manually in tests),
- introduces the `wait_until!` macro—useful for message filtering,
- makes test naming and ordering consistent.