### PR TITLE
feat/conformance 007

### DIFF
--- a/src/protocol/payload/reject.rs
+++ b/src/protocol/payload/reject.rs
@@ -5,7 +5,7 @@ use std::io::{self, Cursor, Read, Write};
 #[derive(Debug)]
 pub struct Reject {
     message: VarStr,
-    ccode: CCode,
+    pub ccode: CCode,
     reason: VarStr,
     // Optional extra data provided by some errors.
     // Currently, all errors which provide this field fill it with
@@ -54,7 +54,7 @@ const CHECKPOINT_CODE: u8 = 0x43;
 const OTHER_CODE: u8 = 0x50;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-enum CCode {
+pub enum CCode {
     Malformed,
     Invalid,
     Obselete,

--- a/src/protocol/payload/reject.rs
+++ b/src/protocol/payload/reject.rs
@@ -102,4 +102,8 @@ impl CCode {
             )),
         }
     }
+
+    pub fn is_obsolete(&self) -> bool {
+        *self == Self::Obselete
+    }
 }

--- a/src/protocol/payload/version.rs
+++ b/src/protocol/payload/version.rs
@@ -44,6 +44,11 @@ impl Version {
         }
     }
 
+    pub fn with_version(mut self, version: u32) -> Self {
+        self.version = ProtocolVersion(version);
+        self
+    }
+
     pub fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
         self.version.encode(buffer)?;
         buffer.write_all(&self.services.to_le_bytes())?;


### PR DESCRIPTION
I've added a section to the test documentation for expected versus current node behaviour. I am unsure if this might not be better to keep in a separate document instead?

In other words, we could update `spec.md` to always contain the expected behaviour (and therefore what we test), and another document for what currently occurs. Thoughts?

I'll update the PR with whatever we decide (I currently haven't updated the spec either).