### PR TITLE
Node start signalling

### DIFF
--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -68,7 +68,7 @@ pub(super) struct NodeConfig {
     pub(super) log_to_stdout: bool,
     /// Setting this option will configure the node to signal it has started through a peer
     /// connection at the supplied address.
-    pub(super) signal_when_started: Option<SocketAddr>,
+    pub(super) start_listener_addr: Option<SocketAddr>,
 }
 
 impl NodeConfig {
@@ -78,7 +78,7 @@ impl NodeConfig {
             initial_peers: HashSet::new(),
             max_peers: 50,
             log_to_stdout: false,
-            signal_when_started: None,
+            start_listener_addr: None,
         }
     }
 }

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -66,6 +66,9 @@ pub(super) struct NodeConfig {
     pub(super) max_peers: usize,
     /// Setting this option to true will enable node logging to stdout.
     pub(super) log_to_stdout: bool,
+    /// Setting this option will configure the node to signal it has started through a peer
+    /// connection at the supplied address.
+    pub(super) signal_when_started: Option<SocketAddr>,
 }
 
 impl NodeConfig {
@@ -75,6 +78,7 @@ impl NodeConfig {
             initial_peers: HashSet::new(),
             max_peers: 50,
             log_to_stdout: false,
+            signal_when_started: None,
         }
     }
 }

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -79,7 +79,7 @@ impl Node {
 
     /// Sets whether to signal the node has started through a peer connection.
     ///
-    /// If set to true, the call to [`start`] will initiate a listener set as a peer on the node and
+    /// If set the call to [`start`] will initiate a listener set as a peer on the node and
     /// will only return once it has received a connection request. This isn't necessary in
     /// scenarios in which the node initates the connections.
     ///

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -84,8 +84,8 @@ impl Node {
     /// scenarios in which the node initates the connections.
     ///
     /// [`start`]: methode@Node::start
-    pub fn signal_when_started(&mut self, addr: SocketAddr) -> &mut Self {
-        self.config.signal_when_started = Some(addr);
+    pub fn start_waits_for_connection(&mut self, addr: SocketAddr) -> &mut Self {
+        self.config.start_listener_addr = Some(addr);
         self
     }
 
@@ -96,7 +96,7 @@ impl Node {
     pub async fn start(&mut self) {
         // Set the listener if start signalling is enabled.
         let mut listener: Option<TcpListener> = None;
-        if let Some(addr) = self.config.signal_when_started {
+        if let Some(addr) = self.config.start_listener_addr {
             let bound_listener = TcpListener::bind(addr).await.unwrap();
 
             self.config.initial_peers.insert(format!(

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -14,18 +14,8 @@ async fn handshake_responder_side() {
 
     let (zig, node_meta) = read_config_file();
 
-    // Create a listener which will be connected to by the node on startup (better than waiting an
-    // arbitrary amount of time in the hopes the node has started).
-    let listener = TcpListener::bind(zig.new_local_addr()).await.unwrap();
-
-    // Create a node and set the listener as an initial peer.
     let mut node = Node::new(node_meta);
-    node.initial_peers(vec![listener.local_addr().unwrap().port()])
-        .start()
-        .await;
-
-    // Yields when a new connection is accepted (signifies the node has started).
-    listener.accept().await.unwrap();
+    node.signal_when_started(zig.new_local_addr()).start().await;
 
     // Connect to the node and initiate handshake.
     let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -135,18 +125,8 @@ async fn reject_non_version_before_handshake() {
 
     let (zig, node_meta) = read_config_file();
 
-    // Create a listener which will be connected to by the node on startup (better than waiting an
-    // arbitrary amount of time in the hopes the node has started).
-    let listener = TcpListener::bind(zig.new_local_addr()).await.unwrap();
-
-    // Create a node and set the listener as an initial peer.
     let mut node = Node::new(node_meta);
-    node.initial_peers(vec![listener.local_addr().unwrap().port()])
-        .start()
-        .await;
-
-    // Yields when a new connection is accepted (signifies the node has started).
-    listener.accept().await.unwrap();
+    node.signal_when_started(zig.new_local_addr()).start().await;
 
     for message in test_messages {
         // (1) connect to node

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -357,18 +357,8 @@ async fn reject_obsolete_versions() {
     let (zig, node_meta) = read_config_file();
     let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
 
-    // Create a listener which will be connected to by the node on startup (better than waiting an
-    // arbitrary amount of time in the hopes the node has started).
-    let listener = TcpListener::bind(zig.new_local_addr()).await.unwrap();
-
-    // Create a node and set the listener as an initial peer.
     let mut node = Node::new(node_meta);
-    node.initial_peers(vec![listener.local_addr().unwrap().port()])
-        .start()
-        .await;
-
-    // Yields when a new connection is accepted (signifies the node has started).
-    listener.accept().await.unwrap();
+    node.signal_when_started(zig.new_local_addr()).start().await;
 
     for obsolete_version_number in obsolete_version_numbers {
         // open connection

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -15,7 +15,9 @@ async fn handshake_responder_side() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.signal_when_started(zig.new_local_addr()).start().await;
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
 
     // Connect to the node and initiate handshake.
     let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -126,7 +128,9 @@ async fn reject_non_version_before_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.signal_when_started(zig.new_local_addr()).start().await;
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
 
     for message in test_messages {
         // (1) connect to node
@@ -358,7 +362,9 @@ async fn reject_obsolete_versions() {
     let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
 
     let mut node = Node::new(node_meta);
-    node.signal_when_started(zig.new_local_addr()).start().await;
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
 
     for obsolete_version_number in obsolete_version_numbers {
         // open connection


### PR DESCRIPTION
This PR abstracts node start signalling through a peer connection. Note the address from the `Config` still needs to be passed in at this stage. 