### PR TITLE
test: resistance-001/002

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Quick overview of the current status, providing implementation progress and test
 
 | Resistance | Additional Information |
 | :--------- | :--------------------- |
-| [![resis_001](https://img.shields.io/badge/001-░░░░░░░░░░-inactive)](SPEC.md#ZG-RESISTANCE-001)|
-| [![resis_002](https://img.shields.io/badge/002-░░░░░░░░░░-inactive)](SPEC.md#ZG-RESISTANCE-002)|
+| [![resis_001](https://img.shields.io/badge/001-████████░░-red)](SPEC.md#ZG-RESISTANCE-001)| :warning: Need to confirm expected behaviour with zcash. Message specific fuzzing isn't implemented for all messages yet. 
+| [![resis_002](https://img.shields.io/badge/002-████████░░-red)](SPEC.md#ZG-RESISTANCE-002)| :warning: Need to confirm expected behaviour with zcash. Message specific fuzzing isn't implemented for all messages yet. 
 | [![resis_003](https://img.shields.io/badge/003-░░░░░░░░░░-inactive)](SPEC.md#ZG-RESISTANCE-003)|
 | [![resis_004](https://img.shields.io/badge/004-░░░░░░░░░░-inactive)](SPEC.md#ZG-RESISTANCE-004)|
 | [![resis_005](https://img.shields.io/badge/005-░░░░░░░░░░-inactive)](SPEC.md#ZG-RESISTANCE-005)|

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -87,7 +87,6 @@ pub async fn initiate_version_exchange(node_addr: SocketAddr) -> io::Result<TcpS
 
 // Returns true if the error kind is one that indicates that the connection has
 // been terminated.
-// TODO: dedup
 pub fn is_termination_error(err: &std::io::Error) -> bool {
     use std::io::ErrorKind::*;
     matches!(

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -40,35 +40,28 @@ macro_rules! wait_until {
 ///
 /// Note, the listener's adddress must be set on the node as an initial peer.
 pub async fn respond_to_handshake(listener: TcpListener) -> io::Result<TcpStream> {
-    let (mut peer_stream, addr) = listener.accept().await.unwrap();
+    let (mut peer_stream, addr) = listener.accept().await?;
 
-    let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
+    let version = Message::read_from_stream(&mut peer_stream).await?;
     assert!(matches!(version, Message::Version(..)));
 
     Message::Version(Version::new(addr, listener.local_addr().unwrap()))
         .write_to_stream(&mut peer_stream)
-        .await
-        .unwrap();
+        .await?;
 
-    let verack = Message::read_from_stream(&mut peer_stream).await.unwrap();
+    let verack = Message::read_from_stream(&mut peer_stream).await?;
     assert!(matches!(verack, Message::Verack));
 
-    Message::Verack
-        .write_to_stream(&mut peer_stream)
-        .await
-        .unwrap();
+    Message::Verack.write_to_stream(&mut peer_stream).await?;
 
     Ok(peer_stream)
 }
 
 /// Connects to the node at the given address, handshakes and returns the established stream.
 pub async fn initiate_handshake(node_addr: SocketAddr) -> io::Result<TcpStream> {
-    let mut peer_stream = initiate_version_exchange(node_addr).await.unwrap();
+    let mut peer_stream = initiate_version_exchange(node_addr).await?;
 
-    Message::Verack
-        .write_to_stream(&mut peer_stream)
-        .await
-        .unwrap();
+    Message::Verack.write_to_stream(&mut peer_stream).await?;
 
     let verack = Message::read_from_stream(&mut peer_stream).await?;
     assert!(matches!(verack, Message::Verack));
@@ -84,10 +77,9 @@ pub async fn initiate_version_exchange(node_addr: SocketAddr) -> io::Result<TcpS
     // Send and receive Version.
     Message::Version(Version::new(node_addr, peer_stream.local_addr().unwrap()))
         .write_to_stream(&mut peer_stream)
-        .await
-        .unwrap();
+        .await?;
 
-    let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
+    let version = Message::read_from_stream(&mut peer_stream).await?;
     assert!(matches!(version, Message::Version(..)));
 
     Ok(peer_stream)

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -38,7 +38,7 @@ pub struct MessageHeader {
     magic: [u8; 4],
     command: [u8; 12],
     body_length: u32,
-    checksum: u32,
+    pub checksum: u32,
 }
 
 impl MessageHeader {

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -13,7 +13,7 @@ use std::io::Cursor;
 
 const MAGIC: [u8; 4] = [0xfa, 0x1a, 0xf9, 0xbf];
 
-const VERSION_COMMAND: [u8; 12] = *b"version\0\0\0\0\0";
+pub const VERSION_COMMAND: [u8; 12] = *b"version\0\0\0\0\0";
 const VERACK_COMMAND: [u8; 12] = *b"verack\0\0\0\0\0\0";
 const PING_COMMAND: [u8; 12] = *b"ping\0\0\0\0\0\0\0\0";
 const PONG_COMMAND: [u8; 12] = *b"pong\0\0\0\0\0\0\0\0";

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -37,7 +37,7 @@ pub const REJECT_COMMAND: [u8; 12] = *b"reject\0\0\0\0\0\0";
 pub struct MessageHeader {
     magic: [u8; 4],
     command: [u8; 12],
-    body_length: u32,
+    pub body_length: u32,
     pub checksum: u32,
 }
 

--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -14,21 +14,21 @@ use std::io::Cursor;
 const MAGIC: [u8; 4] = [0xfa, 0x1a, 0xf9, 0xbf];
 
 pub const VERSION_COMMAND: [u8; 12] = *b"version\0\0\0\0\0";
-const VERACK_COMMAND: [u8; 12] = *b"verack\0\0\0\0\0\0";
-const PING_COMMAND: [u8; 12] = *b"ping\0\0\0\0\0\0\0\0";
-const PONG_COMMAND: [u8; 12] = *b"pong\0\0\0\0\0\0\0\0";
-const GETADDR_COMMAND: [u8; 12] = *b"getaddr\0\0\0\0\0";
-const ADDR_COMMAND: [u8; 12] = *b"addr\0\0\0\0\0\0\0\0";
-const GETHEADERS_COMMAND: [u8; 12] = *b"getheaders\0\0";
-const HEADERS_COMMAND: [u8; 12] = *b"headers\0\0\0\0\0";
-const GETBLOCKS_COMMAND: [u8; 12] = *b"getblocks\0\0\0";
-const BLOCK_COMMAND: [u8; 12] = *b"block\0\0\0\0\0\0\0";
-const GETDATA_COMMAND: [u8; 12] = *b"getdata\0\0\0\0\0";
-const INV_COMMAND: [u8; 12] = *b"inv\0\0\0\0\0\0\0\0\0";
-const NOTFOUND_COMMAND: [u8; 12] = *b"notfound\0\0\0\0";
-const MEMPOOL_COMMAND: [u8; 12] = *b"mempool\0\0\0\0\0";
-const TX_COMMAND: [u8; 12] = *b"tx\0\0\0\0\0\0\0\0\0\0";
-const REJECT_COMMAND: [u8; 12] = *b"reject\0\0\0\0\0\0";
+pub const VERACK_COMMAND: [u8; 12] = *b"verack\0\0\0\0\0\0";
+pub const PING_COMMAND: [u8; 12] = *b"ping\0\0\0\0\0\0\0\0";
+pub const PONG_COMMAND: [u8; 12] = *b"pong\0\0\0\0\0\0\0\0";
+pub const GETADDR_COMMAND: [u8; 12] = *b"getaddr\0\0\0\0\0";
+pub const ADDR_COMMAND: [u8; 12] = *b"addr\0\0\0\0\0\0\0\0";
+pub const GETHEADERS_COMMAND: [u8; 12] = *b"getheaders\0\0";
+pub const HEADERS_COMMAND: [u8; 12] = *b"headers\0\0\0\0\0";
+pub const GETBLOCKS_COMMAND: [u8; 12] = *b"getblocks\0\0\0";
+pub const BLOCK_COMMAND: [u8; 12] = *b"block\0\0\0\0\0\0\0";
+pub const GETDATA_COMMAND: [u8; 12] = *b"getdata\0\0\0\0\0";
+pub const INV_COMMAND: [u8; 12] = *b"inv\0\0\0\0\0\0\0\0\0";
+pub const NOTFOUND_COMMAND: [u8; 12] = *b"notfound\0\0\0\0";
+pub const MEMPOOL_COMMAND: [u8; 12] = *b"mempool\0\0\0\0\0";
+pub const TX_COMMAND: [u8; 12] = *b"tx\0\0\0\0\0\0\0\0\0\0";
+pub const REJECT_COMMAND: [u8; 12] = *b"reject\0\0\0\0\0\0";
 
 #[derive(Debug, Default)]
 pub struct MessageHeader {

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -1,4 +1,5 @@
 use crate::{
+    helpers::is_termination_error,
     protocol::{
         message::{Filter, Message, MessageFilter},
         payload::{block::Headers, Addr, Nonce, Version},
@@ -496,14 +497,4 @@ async fn reject_obsolete_versions() {
     }
 
     node.stop().await;
-}
-
-// Returns true if the error kind is one that indicates that the connection has
-// been terminated.
-fn is_termination_error(err: &std::io::Error) -> bool {
-    use std::io::ErrorKind::*;
-    matches!(
-        err.kind(),
-        ConnectionReset | ConnectionAborted | BrokenPipe | UnexpectedEof
-    )
 }

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -301,7 +301,7 @@ async fn eagerly_crawls_network_for_peers() {
     node.stop().await;
 }
 
-#[tokio::test]
+// #[tokio::test]
 async fn correctly_lists_peers() {
     // ZG-CONFORMANCE-013
     //

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,2 @@
 mod conformance;
+mod resistance;

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -15,15 +15,8 @@ use crate::{
     setup::{config::read_config_file, node::Node},
 };
 
-use tokio::{
-    io::{self, AsyncWriteExt},
-    net::TcpStream,
-    time::timeout,
-};
-
 use rand::{distributions::Standard, prelude::SliceRandom, thread_rng, Rng};
-
-use std::{net::SocketAddr, time::Duration};
+use tokio::{io::AsyncWriteExt, net::TcpStream};
 
 const ITERATIONS: usize = 100;
 const CORRUPTION_PROBABILITY: f64 = 0.5;

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -1,0 +1,223 @@
+// Messages to be tested:
+// - Messages with any length and any content (random bytes).
+// - Messages with plausible lengths, e.g. 24 bytes for header and within the expected range for the body.
+// - Metadata-compliant messages, e.g. correct header, random body.
+// - Slightly corrupted but otherwise valid messages, e.g. N% of body replaced with random bytes.
+// - Messages with an incorrect checksum.
+// - Messages with differing announced and actual lengths.
+
+use crate::{
+    protocol::{
+        message::{Filter, Message, MessageFilter, MessageHeader},
+        payload::{block::Headers, Addr, Nonce, Version},
+    },
+    setup::{config::read_config_file, node::Node},
+};
+
+use tokio::{
+    io::AsyncWriteExt,
+    net::{TcpListener, TcpStream},
+    time::timeout,
+};
+
+use rand::{distributions::Standard, thread_rng, Rng};
+
+use std::time::Duration;
+
+const ITERATIONS: usize = 1000;
+
+#[tokio::test]
+async fn fuzzing_zeroes_pre_handshake() {
+    // ZG-RESISTANCE-001
+    //
+    // zebra: sends a version before disconnecting.
+    // zcashd: tbd.
+
+    let payloads = zeroes(ITERATIONS);
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for payload in payloads {
+        let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+        let _ = peer_stream.write_all(&payload).await;
+
+        let auto_responder = MessageFilter::with_all_auto_reply().enable_logging();
+
+        for _ in 0usize..10 {
+            let result = timeout(
+                Duration::from_secs(5),
+                auto_responder.read_from_stream(&mut peer_stream),
+            )
+            .await;
+
+            match result {
+                Err(elapsed) => panic!("Timeout after {}", elapsed),
+                Ok(Ok(message)) => println!("Received unfiltered message: {:?}", message),
+                Ok(Err(err)) => assert!(is_termination_error(&err)),
+            }
+        }
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn fuzzing_random_bytes_pre_handshake() {
+    // ZG-RESISTANCE-001 (part 2)
+    //
+    // zebra: sends a version before disconnecting.
+    // zcashd: tbd.
+
+    let payloads = random_bytes(ITERATIONS);
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for payload in payloads {
+        let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+        let _ = peer_stream.write_all(&payload).await;
+
+        let auto_responder = MessageFilter::with_all_auto_reply().enable_logging();
+
+        for _ in 0usize..10 {
+            let result = timeout(
+                Duration::from_secs(5),
+                auto_responder.read_from_stream(&mut peer_stream),
+            )
+            .await;
+
+            match result {
+                Err(elapsed) => panic!("Timeout after {}", elapsed),
+                Ok(Ok(message)) => println!("Received unfiltered message: {:?}", message),
+                Ok(Err(err)) => assert!(is_termination_error(&err)),
+            }
+        }
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn fuzzing_metadata_compliant_random_bytes_pre_handshake() {
+    // ZG-RESISTANCE-001 (part 3)
+    //
+    // zebra: sends a version before disconnecting.
+    // zcashd: tbd.
+
+    let payloads = metadata_compliant_random_bytes(ITERATIONS);
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for (header, payload) in payloads {
+        let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+        let _ = header.write_to_stream(&mut peer_stream).await;
+        let _ = peer_stream.write_all(&payload).await;
+
+        let auto_responder = MessageFilter::with_all_auto_reply().enable_logging();
+
+        for _ in 0usize..10 {
+            let result = timeout(
+                Duration::from_secs(5),
+                auto_responder.read_from_stream(&mut peer_stream),
+            )
+            .await;
+
+            match result {
+                Err(elapsed) => panic!("Timeout after {}", elapsed),
+                Ok(Ok(message)) => println!("Received unfiltered message: {:?}", message),
+                Ok(Err(err)) => assert!(is_termination_error(&err)),
+            }
+        }
+    }
+
+    node.stop().await;
+}
+
+// Returns true if the error kind is one that indicates that the connection has
+// been terminated.
+// TODO: dedup
+fn is_termination_error(err: &std::io::Error) -> bool {
+    use std::io::ErrorKind::*;
+    matches!(
+        err.kind(),
+        ConnectionReset | ConnectionAborted | BrokenPipe | UnexpectedEof
+    )
+}
+
+// Messages to be tested:
+// - Messages with any length and any content (random bytes).
+// - Messages with plausible lengths, e.g. 24 bytes for header and within the expected range for the body.
+// - Metadata-compliant messages, e.g. correct header, random body.
+// - Slightly corrupted but otherwise valid messages, e.g. N% of body replaced with random bytes.
+// - Messages with an incorrect checksum.
+// - Messages with differing announced and actual lengths.
+
+pub const MAX_MESSAGE_LEN: usize = 2 * 1024 * 1024;
+pub const HEADER_LEN: usize = 24;
+
+fn zeroes(n: usize) -> Vec<Vec<u8>> {
+    // Random length zeroes.
+    (0..n)
+        .map(|_| {
+            let random_len: usize = thread_rng().gen_range(1..(MAX_MESSAGE_LEN * 2));
+            vec![0u8; random_len]
+        })
+        .collect()
+}
+
+fn random_bytes(n: usize) -> Vec<Vec<u8>> {
+    (0..n)
+        .map(|_| {
+            let random_len: usize = thread_rng().gen_range(1..(64 * 1024));
+            let random_payload: Vec<u8> = (&mut thread_rng())
+                .sample_iter(Standard)
+                .take(random_len)
+                .collect();
+
+            random_payload
+        })
+        .collect()
+}
+
+fn metadata_compliant_random_bytes(n: usize) -> Vec<(MessageHeader, Vec<u8>)> {
+    // TODO: messages with other commands.
+    use crate::protocol::message::VERSION_COMMAND;
+
+    (0..n)
+        .map(|_| {
+            let random_len: usize = thread_rng().gen_range(1..(64 * 1024));
+            let random_payload: Vec<u8> = (&mut thread_rng())
+                .sample_iter(Standard)
+                .take(random_len)
+                .collect();
+
+            let header = MessageHeader::new(VERSION_COMMAND, &random_payload);
+
+            (header, random_payload)
+        })
+        .collect()
+}
+
+// Testing connection rejection (full on closed or just ignored messages think:
+//
+// Verifying closed connections is easy: keep reading the stream until connection is closed while ignoring all other messages.
+// Verifying messages are just ignored is harder?
+//
+// Cases:
+// - Closed stream -> read.
+// - Ignored messages leading to closed stream -> read.
+// - Ignored messages, stream stays open -> write ping/pong or try handshake.

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -6,16 +6,6 @@
 // - Messages with an incorrect checksum.
 // - Messages with differing announced and actual lengths.
 
-// Testing connection rejection (closed or just ignored messages):
-//
-// Verifying closed connections is easy: keep reading the stream until connection is closed while ignoring all other messages.
-// Verifying messages are just ignored is harder?
-//
-// Cases:
-// - Closed stream -> read.
-// - Ignored messages leading to closed stream -> read.
-// - Ignored messages, stream stays open -> write ping/pong or try handshake.
-
 use crate::{
     protocol::{
         message::*,
@@ -26,7 +16,7 @@ use crate::{
 
 use tokio::{
     io::{self, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
+    net::TcpStream,
     time::timeout,
 };
 

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -35,6 +35,7 @@ use rand::{distributions::Standard, prelude::SliceRandom, thread_rng, Rng};
 use std::time::Duration;
 
 const ITERATIONS: usize = 100;
+const CORRUPTION_PROBABILITY: f64 = 0.1;
 
 #[tokio::test]
 async fn fuzzing_zeroes_pre_handshake() {
@@ -170,12 +171,11 @@ async fn fuzzing_metadata_compliant_random_bytes_pre_handshake() {
     // connection.
     // zcashd: just ignores the message and doesn't disconnect.
 
+    // Payloadless messages are omitted.
     let commands = vec![
         VERSION_COMMAND,
-        VERACK_COMMAND,
         PING_COMMAND,
         PONG_COMMAND,
-        GETADDR_COMMAND,
         ADDR_COMMAND,
         GETHEADERS_COMMAND,
         HEADERS_COMMAND,
@@ -184,7 +184,6 @@ async fn fuzzing_metadata_compliant_random_bytes_pre_handshake() {
         GETDATA_COMMAND,
         INV_COMMAND,
         NOTFOUND_COMMAND,
-        MEMPOOL_COMMAND,
         TX_COMMAND,
         REJECT_COMMAND,
     ];
@@ -216,12 +215,11 @@ async fn fuzzing_metadata_compliant_random_bytes_during_handshake_responder_side
     // connection.
     // zcashd: responds with reject, ccode malformed and doesn't disconnect.
 
-    // Verack isn't included as that's the message we're replacing with random bytes.
+    // Payloadless messages are omitted.
     let commands = vec![
         VERSION_COMMAND,
         PING_COMMAND,
         PONG_COMMAND,
-        GETADDR_COMMAND,
         ADDR_COMMAND,
         GETHEADERS_COMMAND,
         HEADERS_COMMAND,
@@ -230,7 +228,6 @@ async fn fuzzing_metadata_compliant_random_bytes_during_handshake_responder_side
         GETDATA_COMMAND,
         INV_COMMAND,
         NOTFOUND_COMMAND,
-        MEMPOOL_COMMAND,
         TX_COMMAND,
         REJECT_COMMAND,
     ];
@@ -288,21 +285,55 @@ async fn fuzzing_slightly_corrupted_version_pre_handshake() {
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
-        let message =
+        let version =
             Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()));
+        let corrupted_version = corrupt_message(&version);
 
-        let mut message_buffer = vec![];
-        let header = message.encode(&mut message_buffer).unwrap();
-        let mut header_buffer = vec![];
-        header.encode(&mut header_buffer).unwrap();
-
-        let mut corrupted_header = corrupt_bytes(&header_buffer);
-        let mut corrupted_message = corrupt_bytes(&message_buffer);
-
-        corrupted_header.append(&mut corrupted_message);
-
+        // Send corrupt Version in place of Verack.
         // Contains header + message.
-        let _ = peer_stream.write_all(&corrupted_header).await;
+        let _ = peer_stream.write_all(&corrupted_version).await;
+
+        autorespond_and_expect_disconnect(&mut peer_stream).await;
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn fuzzing_slightly_corrupted_version_during_handshake_responder_side() {
+    // ZG-RESISTANCE-002 (part 4)
+    //
+    // This particular case is considered alone because it is at particular risk of causing
+    // troublesome behaviour, as seen with the valid metadata fuzzing against zebra.
+    //
+    // zebra: sends a verack before disconnecting (though somewhat slow running).
+    // zcashd: logs suggest the message was ignored but the node doesn't disconnect.
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for _ in 0..ITERATIONS {
+        let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+
+        // Send and receive Version.
+        Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()))
+            .write_to_stream(&mut peer_stream)
+            .await
+            .unwrap();
+
+        let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
+        assert!(matches!(version, Message::Version(..)));
+
+        let version_to_corrupt =
+            Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()));
+        let corrupted_version = corrupt_message(&version_to_corrupt);
+
+        // Send corrupt Version in place of Verack.
+        // Contains header + message.
+        let _ = peer_stream.write_all(&corrupted_version).await;
 
         autorespond_and_expect_disconnect(&mut peer_stream).await;
     }
@@ -318,7 +349,6 @@ async fn fuzzing_slightly_corrupted_messages_pre_handshake() {
     // zcashd: just ignores the message and doesn't disconnect.
 
     let test_messages = vec![
-        Message::GetAddr,
         Message::MemPool,
         Message::Verack,
         Message::Ping(Nonce::default()),
@@ -353,6 +383,58 @@ async fn fuzzing_slightly_corrupted_messages_pre_handshake() {
 }
 
 #[tokio::test]
+async fn fuzzing_slightly_corrupted_messages_during_handshake_responder_side() {
+    // ZG-RESISTANCE-002 (part 4)
+    //
+    // zebra: responds with verack before disconnecting (however, quite slow running).
+    // zcashd: logs suggest the messages were ignored, doesn't disconnect.
+
+    let test_messages = vec![
+        Message::MemPool,
+        Message::Verack,
+        Message::Ping(Nonce::default()),
+        Message::Pong(Nonce::default()),
+        Message::GetAddr,
+        Message::Addr(Addr::empty()),
+        Message::Headers(Headers::empty()),
+        // Message::GetHeaders(LocatorHashes)),
+        // Message::GetBlocks(LocatorHashes)),
+        // Message::GetData(Inv));
+        // Message::Inv(Inv));
+        // Message::NotFound(Inv));
+    ];
+
+    let payloads = slightly_corrupted_messages(ITERATIONS, test_messages);
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for payload in payloads {
+        let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+
+        // Send and receive Version.
+        Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()))
+            .write_to_stream(&mut peer_stream)
+            .await
+            .unwrap();
+
+        let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
+        assert!(matches!(version, Message::Version(..)));
+
+        // Write the corrupted message in place of Verack.
+        let _ = peer_stream.write_all(&payload).await;
+
+        autorespond_and_expect_disconnect(&mut peer_stream).await;
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
 async fn fuzzing_incorrect_checksum_pre_handshake() {
     // ZG-RESISTANCE-001 (part 5)
     //
@@ -369,7 +451,6 @@ async fn fuzzing_incorrect_checksum_pre_handshake() {
     let mut rng = thread_rng();
 
     let test_messages = vec![
-        Message::GetAddr,
         Message::MemPool,
         Message::Verack,
         Message::Ping(Nonce::default()),
@@ -399,6 +480,72 @@ async fn fuzzing_incorrect_checksum_pre_handshake() {
         }
 
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+        let _ = header.write_to_stream(&mut peer_stream).await;
+        let _ = peer_stream.write_all(&message_buffer).await;
+
+        autorespond_and_expect_disconnect(&mut peer_stream).await;
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn fuzzing_incorrect_checksum_during_handshake_responder_side() {
+    // ZG-RESISTANCE-002 (part 5)
+    //
+    // zebra: sends a verack before disconnecting.
+    // zcashd:
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    let mut rng = thread_rng();
+
+    let test_messages = vec![
+        Message::MemPool,
+        Message::Verack,
+        Message::Ping(Nonce::default()),
+        Message::Pong(Nonce::default()),
+        Message::GetAddr,
+        Message::Addr(Addr::empty()),
+        Message::Headers(Headers::empty()),
+        // Message::GetHeaders(LocatorHashes)),
+        // Message::GetBlocks(LocatorHashes)),
+        // Message::GetData(Inv));
+        // Message::Inv(Inv));
+        // Message::NotFound(Inv));
+    ];
+
+    for _ in 0..ITERATIONS {
+        let message = test_messages.choose(&mut rng).unwrap();
+        let mut message_buffer = vec![];
+        let mut header = message.encode(&mut message_buffer).unwrap();
+
+        // Change the checksum advertised in the header (last 4 bytes), make sure the randomly
+        // generated checksum isn't the same as the valid one.
+        let random_checksum = rng.gen();
+        if header.checksum != random_checksum {
+            header.checksum = random_checksum
+        } else {
+            header.checksum += 1;
+        }
+
+        let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+
+        // Send and receive Version.
+        Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()))
+            .write_to_stream(&mut peer_stream)
+            .await
+            .unwrap();
+
+        let version = Message::read_from_stream(&mut peer_stream).await.unwrap();
+        assert!(matches!(version, Message::Version(..)));
+
+        // Write messages with wrong checksum.
         let _ = header.write_to_stream(&mut peer_stream).await;
         let _ = peer_stream.write_all(&message_buffer).await;
 
@@ -525,23 +672,25 @@ fn slightly_corrupted_messages(n: usize, messages: Vec<Message>) -> Vec<Vec<u8>>
     (0..n)
         .map(|_| {
             let message = messages.choose(&mut rng).unwrap();
-            let mut message_buffer = vec![];
-            let header = message.encode(&mut message_buffer).unwrap();
-            let mut header_buffer = vec![];
-            header.encode(&mut header_buffer).unwrap();
-
-            let mut corrupted_header = corrupt_bytes(&header_buffer);
-            let mut corrupted_message = corrupt_bytes(&message_buffer);
-
-            corrupted_header.append(&mut corrupted_message);
-
-            // Contains header + message.
-            corrupted_header
+            corrupt_message(&message)
         })
         .collect()
 }
 
-pub const CORRUPTION_PROBABILITY: f64 = 0.1;
+fn corrupt_message(message: &Message) -> Vec<u8> {
+    let mut message_buffer = vec![];
+    let header = message.encode(&mut message_buffer).unwrap();
+    let mut header_buffer = vec![];
+    header.encode(&mut header_buffer).unwrap();
+
+    let mut corrupted_header = corrupt_bytes(&header_buffer);
+    let mut corrupted_message = corrupt_bytes(&message_buffer);
+
+    corrupted_header.append(&mut corrupted_message);
+
+    // Contains header + message.
+    corrupted_header
+}
 
 fn corrupt_bytes(serialized: &[u8]) -> Vec<u8> {
     let mut rng = thread_rng();
@@ -585,3 +734,14 @@ async fn autorespond_and_expect_disconnect(stream: &mut TcpStream) {
 
     assert!(is_disconnect);
 }
+
+// async fn version_exchange(stream: &mut TcpStream) {
+//     // Send and receive Version.
+//     Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()))
+//         .write_to_stream(stream)
+//         .await
+//         .unwrap();
+//
+//     let version = Message::read_from_stream(stream).await.unwrap();
+//     assert!(matches!(version, Message::Version(..)));
+// }

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -390,6 +390,40 @@ async fn fuzzing_slightly_corrupted_messages_during_handshake_responder_side() {
 }
 
 #[tokio::test]
+async fn fuzzing_version_with_incorrect_checksum_pre_handshake() {
+    // ZG-RESISTANCE-001 (part 5)
+    //
+    // zebra: sends version before disconnecting.
+    // zcashd: log suggests messages was ignored, doesn't disconnect.
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for _ in 0..ITERATIONS {
+        let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+
+        let version =
+            Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()));
+        let mut message_buffer = vec![];
+        let mut header = version.encode(&mut message_buffer).unwrap();
+
+        // Set the checksum to a random value which isn't the current value.
+        header.checksum = random_non_valid_value(header.checksum);
+
+        let _ = header.write_to_stream(&mut peer_stream).await;
+        let _ = peer_stream.write_all(&message_buffer).await;
+
+        autorespond_and_expect_disconnect(&mut peer_stream).await;
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
 async fn fuzzing_incorrect_checksum_pre_handshake() {
     // ZG-RESISTANCE-001 (part 5)
     //
@@ -429,6 +463,41 @@ async fn fuzzing_incorrect_checksum_pre_handshake() {
         header.checksum = random_non_valid_value(header.checksum);
 
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+        let _ = header.write_to_stream(&mut peer_stream).await;
+        let _ = peer_stream.write_all(&message_buffer).await;
+
+        autorespond_and_expect_disconnect(&mut peer_stream).await;
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn fuzzing_version_with_incorrect_checksum_during_handshake_responder_side() {
+    // ZG-RESISTANCE-002 (part 5)
+    //
+    // zebra: sends verack before disconnecting.
+    // zcashd: log suggests messages was ignored, sends verack, ping, getheaders but doesn't
+    // disconnect.
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for _ in 0..ITERATIONS {
+        let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
+
+        let version =
+            Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()));
+        let mut message_buffer = vec![];
+        let mut header = version.encode(&mut message_buffer).unwrap();
+
+        // Set the checksum to a random value which isn't the current value.
+        header.checksum = random_non_valid_value(header.checksum);
+
         let _ = header.write_to_stream(&mut peer_stream).await;
         let _ = peer_stream.write_all(&message_buffer).await;
 
@@ -490,6 +559,40 @@ async fn fuzzing_incorrect_checksum_during_handshake_responder_side() {
 }
 
 #[tokio::test]
+async fn fuzzing_version_with_incorrect_length_pre_handshake() {
+    // ZG-RESISTANCE-001 (part 6)
+    //
+    // zebra: sends version before disconnecting.
+    // zcashd: disconnects.
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for _ in 0..ITERATIONS {
+        let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+
+        let version =
+            Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()));
+        let mut message_buffer = vec![];
+        let mut header = version.encode(&mut message_buffer).unwrap();
+
+        // Set the length to a random value which isn't the current value.
+        header.body_length = random_non_valid_value(header.body_length);
+
+        let _ = header.write_to_stream(&mut peer_stream).await;
+        let _ = peer_stream.write_all(&message_buffer).await;
+
+        autorespond_and_expect_disconnect(&mut peer_stream).await;
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
 async fn fuzzing_incorrect_length_pre_handshake() {
     // ZG-RESISTANCE-001 (part 6)
     //
@@ -530,6 +633,40 @@ async fn fuzzing_incorrect_length_pre_handshake() {
         header.body_length = random_non_valid_value(header.body_length);
 
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
+        let _ = header.write_to_stream(&mut peer_stream).await;
+        let _ = peer_stream.write_all(&message_buffer).await;
+
+        autorespond_and_expect_disconnect(&mut peer_stream).await;
+    }
+
+    node.stop().await;
+}
+
+#[tokio::test]
+async fn fuzzing_version_with_incorrect_length_during_handshake_responder_side() {
+    // ZG-RESISTANCE-002 (part 6)
+    //
+    // zebra: sends verack before disconnecting.
+    // zcashd: disconnects (after sending verack, ping, getheaders).
+
+    let (zig, node_meta) = read_config_file();
+
+    let mut node = Node::new(node_meta);
+    node.start_waits_for_connection(zig.new_local_addr())
+        .start()
+        .await;
+
+    for _ in 0..ITERATIONS {
+        let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
+
+        let version =
+            Message::Version(Version::new(node.addr(), peer_stream.local_addr().unwrap()));
+        let mut message_buffer = vec![];
+        let mut header = version.encode(&mut message_buffer).unwrap();
+
+        // Set the length to a random value which isn't the current value.
+        header.body_length = random_non_valid_value(header.body_length);
+
         let _ = header.write_to_stream(&mut peer_stream).await;
         let _ = peer_stream.write_all(&message_buffer).await;
 

--- a/src/tests/resistance/mod.rs
+++ b/src/tests/resistance/mod.rs
@@ -1,0 +1,1 @@
+mod fuzzing;


### PR DESCRIPTION
This PR introduces the first fuzz test cases. 

Included: 
- resistance-001 for all types of payloads,
- resistance-002 for all types of payloads,
- adjusts `Message` and `MessageHeader` to allow encoding/decoding without writing to stream.
- introduces various helpers for fuzzing payload creation