### PR TITLE
feat: zcash now uses whitebind instead of bind

### DIFF
--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -242,7 +242,7 @@ pub(super) struct ZcashdConfigFile;
 impl ZcashdConfigFile {
     pub(super) fn generate(config: &NodeConfig) -> String {
         let mut contents = format!(
-            "testnet=1\nbind={}\nmaxconnections={}\n",
+            "testnet=1\nwhitebind={}\nmaxconnections={}\n",
             config.local_addr, config.max_peers
         );
 


### PR DESCRIPTION
This allows us to circumvent our chain being too short checks.

All tests that were green, are still green.