### PR TITLE
fix: Header tx_count must be zero for encoding

### DIFF
--- a/src/protocol/message.rs
+++ b/src/protocol/message.rs
@@ -1,5 +1,6 @@
 use crate::protocol::payload::{
     block::{Block, Headers, LocatorHashes},
+    codec::Codec,
     Addr, Inv, Nonce, Reject, Tx, Version,
 };
 

--- a/src/protocol/payload/addr.rs
+++ b/src/protocol/payload/addr.rs
@@ -11,25 +11,20 @@ use std::{
 
 #[derive(Debug)]
 pub struct Addr {
-    count: VarInt,
     addrs: Vec<NetworkAddr>,
 }
 
 impl Addr {
     pub fn empty() -> Self {
-        Self {
-            count: VarInt(0),
-            addrs: Vec::new(),
-        }
+        Self { addrs: Vec::new() }
     }
 
     pub fn new(addrs: Vec<NetworkAddr>) -> Self {
-        let count = VarInt(addrs.len());
-        Addr { count, addrs }
+        Addr { addrs }
     }
 
     pub fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
-        self.count.encode(buffer)?;
+        VarInt(self.addrs.len()).encode(buffer)?;
 
         for addr in &self.addrs {
             addr.encode(buffer)?;
@@ -39,15 +34,15 @@ impl Addr {
     }
 
     pub fn decode(bytes: &mut Cursor<&[u8]>) -> io::Result<Self> {
-        let count = VarInt::decode(bytes)?;
-        let mut addrs = Vec::with_capacity(count.0);
+        let count = *VarInt::decode(bytes)?;
+        let mut addrs = Vec::with_capacity(count);
 
-        for _ in 0..count.0 {
+        for _ in 0..count {
             let addr = NetworkAddr::decode(bytes)?;
             addrs.push(addr);
         }
 
-        Ok(Self { count, addrs })
+        Ok(Self::new(addrs))
     }
 
     /// Returns an iterator over its list of [NetworkAddr]'s

--- a/src/protocol/payload/codec.rs
+++ b/src/protocol/payload/codec.rs
@@ -1,0 +1,29 @@
+use super::VarInt;
+
+pub trait Codec {
+    fn encode(&self, buffer: &mut Vec<u8>) -> std::io::Result<()>;
+    fn decode(bytes: &mut std::io::Cursor<&[u8]>) -> std::io::Result<Self>
+    where
+        Self: Sized;
+}
+
+impl<T: Codec> Codec for Vec<T> {
+    fn encode(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+        VarInt(self.len()).encode(buffer)?;
+        for element in self {
+            element.encode(buffer)?;
+        }
+
+        Ok(())
+    }
+
+    fn decode(bytes: &mut std::io::Cursor<&[u8]>) -> std::io::Result<Self>
+    where
+        Self: Sized,
+    {
+        let length = *VarInt::decode(bytes)?;
+        (0..length)
+            .map(|_| T::decode(bytes))
+            .collect::<std::io::Result<Self>>()
+    }
+}

--- a/src/protocol/payload/inv.rs
+++ b/src/protocol/payload/inv.rs
@@ -4,13 +4,12 @@ use std::io::{self, Cursor, Write};
 
 #[derive(Debug)]
 pub struct Inv {
-    count: VarInt,
     inventory: Vec<InvHash>,
 }
 
 impl Inv {
     pub fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
-        self.count.encode(buffer)?;
+        VarInt(self.inventory.len()).encode(buffer)?;
 
         for hash in &self.inventory {
             hash.encode(buffer)?;
@@ -28,7 +27,7 @@ impl Inv {
             inventory.push(hash);
         }
 
-        Ok(Self { count, inventory })
+        Ok(Self { inventory })
     }
 }
 

--- a/src/protocol/payload/inv.rs
+++ b/src/protocol/payload/inv.rs
@@ -1,4 +1,4 @@
-use crate::protocol::payload::{read_n_bytes, Hash, VarInt};
+use crate::protocol::payload::{codec::Codec, read_n_bytes, Hash};
 
 use std::io::{self, Cursor, Write};
 
@@ -7,27 +7,15 @@ pub struct Inv {
     inventory: Vec<InvHash>,
 }
 
-impl Inv {
-    pub fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
-        VarInt(self.inventory.len()).encode(buffer)?;
-
-        for hash in &self.inventory {
-            hash.encode(buffer)?;
-        }
-
-        Ok(())
+impl Codec for Inv {
+    fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
+        self.inventory.encode(buffer)
     }
 
-    pub fn decode(bytes: &mut Cursor<&[u8]>) -> io::Result<Self> {
-        let count = VarInt::decode(bytes)?;
-        let mut inventory = Vec::with_capacity(count.0);
-
-        for _ in 0..count.0 {
-            let hash = InvHash::decode(bytes)?;
-            inventory.push(hash);
-        }
-
-        Ok(Self { inventory })
+    fn decode(bytes: &mut Cursor<&[u8]>) -> io::Result<Self> {
+        Ok(Self {
+            inventory: Vec::decode(bytes)?,
+        })
     }
 }
 
@@ -37,7 +25,7 @@ struct InvHash {
     hash: Hash,
 }
 
-impl InvHash {
+impl Codec for InvHash {
     fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
         self.kind.encode(buffer)?;
         self.hash.encode(buffer)?;
@@ -61,7 +49,7 @@ enum ObjectKind {
     FilteredBlock,
 }
 
-impl ObjectKind {
+impl Codec for ObjectKind {
     fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
         let value: u32 = match self {
             Self::Error => 0,

--- a/src/protocol/payload/version.rs
+++ b/src/protocol/payload/version.rs
@@ -23,8 +23,7 @@ pub struct Version {
 impl Version {
     pub fn new(addr_recv: SocketAddr, addr_from: SocketAddr) -> Self {
         Self {
-            // TODO: make constants.
-            version: ProtocolVersion(170_013),
+            version: ProtocolVersion::current(),
             services: 1,
             timestamp: Utc::now(),
             addr_recv: NetworkAddr {

--- a/src/protocol/payload/version.rs
+++ b/src/protocol/payload/version.rs
@@ -1,4 +1,6 @@
-use crate::protocol::payload::{addr::NetworkAddr, read_n_bytes, Nonce, ProtocolVersion, VarStr};
+use crate::protocol::payload::{
+    addr::NetworkAddr, codec::Codec, read_n_bytes, Nonce, ProtocolVersion, VarStr,
+};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 
@@ -47,8 +49,10 @@ impl Version {
         self.version = ProtocolVersion(version);
         self
     }
+}
 
-    pub fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
+impl Codec for Version {
+    fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
         self.version.encode(buffer)?;
         buffer.write_all(&self.services.to_le_bytes())?;
         buffer.write_all(&self.timestamp.timestamp().to_le_bytes())?;
@@ -64,7 +68,7 @@ impl Version {
         Ok(())
     }
 
-    pub fn decode(bytes: &mut Cursor<&[u8]>) -> io::Result<Self> {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> io::Result<Self> {
         let version = ProtocolVersion::decode(bytes)?;
         let services = u64::from_le_bytes(read_n_bytes(bytes)?);
         let timestamp = i64::from_le_bytes(read_n_bytes(bytes)?);


### PR DESCRIPTION
The spec states that the `tx_count` is always zero when transmitted in the Header message.

This removes the `tx_count` from the header field, instead opting to encode / decode the VarInt according to its purpose at the next highest level.

So for a `Block` message it will encode the actual tx count, and for `Headers` each `Header` will have a `VarInt(0)` appended.