### PR TITLE
Add action to seed node with genesis blocks on startup

### DIFF
--- a/src/protocol/payload/block.rs
+++ b/src/protocol/payload/block.rs
@@ -61,6 +61,24 @@ impl Block {
     pub fn double_sha256(&self) -> std::io::Result<Hash> {
         self.header.double_sha256()
     }
+
+    /// Creates the first block on the testnet chain
+    pub fn genesis_0() -> Self {
+        let mut cursor = std::io::Cursor::new(&crate::vectors::BLOCK_TESTNET_GENESIS_BYTES[..]);
+        Block::decode(&mut cursor).unwrap()
+    }
+
+    /// Creates the second block on the testnet chain
+    pub fn genesis_1() -> Self {
+        let mut cursor = std::io::Cursor::new(&crate::vectors::BLOCK_TESTNET_1_BYTES[..]);
+        Block::decode(&mut cursor).unwrap()
+    }
+
+    /// Creates the third block on the testnet chain
+    pub fn genesis_2() -> Self {
+        let mut cursor = std::io::Cursor::new(&crate::vectors::BLOCK_TESTNET_2_BYTES[..]);
+        Block::decode(&mut cursor).unwrap()
+    }
 }
 
 impl Codec for Block {

--- a/src/protocol/payload/block.rs
+++ b/src/protocol/payload/block.rs
@@ -10,8 +10,8 @@ use sha2::Digest;
 #[derive(Debug)]
 pub struct LocatorHashes {
     version: ProtocolVersion,
-    block_locator_hashes: Vec<Hash>,
-    hash_stop: Hash,
+    pub block_locator_hashes: Vec<Hash>,
+    pub hash_stop: Hash,
 }
 
 impl LocatorHashes {
@@ -96,7 +96,7 @@ impl Codec for Block {
 
 #[derive(Debug)]
 pub struct Headers {
-    headers: Vec<Header>,
+    pub headers: Vec<Header>,
 }
 
 impl Headers {
@@ -122,7 +122,7 @@ impl Codec for Headers {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Header {
     version: ProtocolVersion,
     prev_block: Hash,
@@ -165,7 +165,7 @@ impl Codec for Header {
 
 impl Header {
     /// Calculates the double Sha256 hash for [Header]
-    fn double_sha256(&self) -> std::io::Result<Hash> {
+    pub fn double_sha256(&self) -> std::io::Result<Hash> {
         let mut buffer = Vec::new();
 
         self.encode_without_tx_count(&mut buffer)?;

--- a/src/protocol/payload/block.rs
+++ b/src/protocol/payload/block.rs
@@ -63,19 +63,19 @@ impl Block {
     }
 
     /// Creates the first block on the testnet chain
-    pub fn genesis_0() -> Self {
+    pub fn testnet_genesis() -> Self {
         let mut cursor = std::io::Cursor::new(&crate::vectors::BLOCK_TESTNET_GENESIS_BYTES[..]);
         Block::decode(&mut cursor).unwrap()
     }
 
     /// Creates the second block on the testnet chain
-    pub fn genesis_1() -> Self {
+    pub fn testnet_1() -> Self {
         let mut cursor = std::io::Cursor::new(&crate::vectors::BLOCK_TESTNET_1_BYTES[..]);
         Block::decode(&mut cursor).unwrap()
     }
 
     /// Creates the third block on the testnet chain
-    pub fn genesis_2() -> Self {
+    pub fn testnet_2() -> Self {
         let mut cursor = std::io::Cursor::new(&crate::vectors::BLOCK_TESTNET_2_BYTES[..]);
         Block::decode(&mut cursor).unwrap()
     }

--- a/src/protocol/payload/inv.rs
+++ b/src/protocol/payload/inv.rs
@@ -19,8 +19,7 @@ impl Codec for Inv {
     }
 }
 
-#[derive(Debug)]
-struct InvHash {
+pub struct InvHash {
     kind: ObjectKind,
     hash: Hash,
 }

--- a/src/protocol/payload/inv.rs
+++ b/src/protocol/payload/inv.rs
@@ -4,7 +4,11 @@ use std::io::{self, Cursor, Write};
 
 #[derive(Debug)]
 pub struct Inv {
-    inventory: Vec<InvHash>,
+
+impl Inv {
+    pub fn new(inventory: Vec<InvHash>) -> Self {
+        Self { inventory }
+    }
 }
 
 impl Codec for Inv {
@@ -24,6 +28,12 @@ pub struct InvHash {
     hash: Hash,
 }
 
+impl InvHash {
+    pub fn new(kind: ObjectKind, hash: Hash) -> Self {
+        Self { kind, hash }
+    }
+}
+
 impl Codec for InvHash {
     fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
         self.kind.encode(buffer)?;
@@ -40,8 +50,7 @@ impl Codec for InvHash {
     }
 }
 
-#[derive(Debug)]
-enum ObjectKind {
+pub enum ObjectKind {
     Error,
     Tx,
     Block,

--- a/src/protocol/payload/inv.rs
+++ b/src/protocol/payload/inv.rs
@@ -2,8 +2,10 @@ use crate::protocol::payload::{codec::Codec, read_n_bytes, Hash};
 
 use std::io::{self, Cursor, Write};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Inv {
+    pub inventory: Vec<InvHash>,
+}
 
 impl Inv {
     pub fn new(inventory: Vec<InvHash>) -> Self {
@@ -23,6 +25,7 @@ impl Codec for Inv {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub struct InvHash {
     kind: ObjectKind,
     hash: Hash,
@@ -50,6 +53,7 @@ impl Codec for InvHash {
     }
 }
 
+#[derive(Debug, PartialEq)]
 pub enum ObjectKind {
     Error,
     Tx,

--- a/src/protocol/payload/mod.rs
+++ b/src/protocol/payload/mod.rs
@@ -139,7 +139,7 @@ impl VarStr {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Hash([u8; 32]);
 
 impl Hash {

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -84,7 +84,7 @@ impl NodeConfig {
 }
 
 /// Describes the node kind, currently supports the two known variants.
-#[derive(Deserialize, Debug, Clone, Copy)]
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 #[serde(rename_all(deserialize = "lowercase"))]
 pub(super) enum NodeKind {
     Zebra,

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -9,6 +9,8 @@ use std::{
     path::PathBuf,
 };
 
+use crate::setup::node::Action;
+
 const NODE_PORT: u16 = 8080;
 
 /// Reads the contents of Ziggurat's configuration file.
@@ -66,9 +68,8 @@ pub(super) struct NodeConfig {
     pub(super) max_peers: usize,
     /// Setting this option to true will enable node logging to stdout.
     pub(super) log_to_stdout: bool,
-    /// Setting this option will configure the node to signal it has started through a peer
-    /// connection at the supplied address.
-    pub(super) start_listener_addr: Option<SocketAddr>,
+    /// Defines the intial action to take once the node has started.
+    pub(super) initial_action: Action,
 }
 
 impl NodeConfig {
@@ -78,7 +79,7 @@ impl NodeConfig {
             initial_peers: HashSet::new(),
             max_peers: 50,
             log_to_stdout: false,
-            start_listener_addr: None,
+            initial_action: Action::None,
         }
     }
 }

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -4,7 +4,10 @@ use crate::{
         message::{Filter, Message, MessageFilter},
         payload::{block::Headers, Addr, Nonce, Version},
     },
-    setup::{config::read_config_file, node::Node},
+    setup::{
+        config::read_config_file,
+        node::{Action, Node},
+    },
 };
 
 use tokio::net::{TcpListener, TcpStream};
@@ -16,7 +19,7 @@ async fn handshake_responder_side() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -129,7 +132,7 @@ async fn reject_non_version_before_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -467,7 +470,7 @@ async fn reject_obsolete_versions() {
     let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -4,7 +4,10 @@ use crate::{
         message::{Message, MessageFilter},
         payload::{addr::NetworkAddr, block::Headers, reject::CCode, Addr, Nonce, Version},
     },
-    setup::{config::read_config_file, node::Node},
+    setup::{
+        config::read_config_file,
+        node::{Action, Node},
+    },
     wait_until,
 };
 
@@ -92,7 +95,7 @@ async fn reject_invalid_messages() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -228,7 +231,7 @@ async fn eagerly_crawls_network_for_peers() {
 
     // start the node
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -330,7 +333,7 @@ async fn correctly_lists_peers() {
 
     // Create a node and main connection
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -16,7 +16,10 @@ use crate::{
         message::*,
         payload::{block::Headers, Addr, Nonce, Version},
     },
-    setup::{config::read_config_file, node::Node},
+    setup::{
+        config::read_config_file,
+        node::{Action, Node},
+    },
 };
 
 use rand::{
@@ -43,7 +46,7 @@ async fn fuzzing_zeroes_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -70,7 +73,7 @@ async fn fuzzing_zeroes_during_handshake_responder_side() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -99,7 +102,7 @@ async fn fuzzing_random_bytes_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -126,7 +129,7 @@ async fn fuzzing_random_bytes_during_handshake_responder_side() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -173,7 +176,7 @@ async fn fuzzing_metadata_compliant_random_bytes_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -219,7 +222,7 @@ async fn fuzzing_metadata_compliant_random_bytes_during_handshake_responder_side
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -254,7 +257,7 @@ async fn fuzzing_slightly_corrupted_version_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -288,7 +291,7 @@ async fn fuzzing_slightly_corrupted_version_during_handshake_responder_side() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -337,7 +340,7 @@ async fn fuzzing_slightly_corrupted_messages_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -379,7 +382,7 @@ async fn fuzzing_slightly_corrupted_messages_during_handshake_responder_side() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -406,7 +409,7 @@ async fn fuzzing_version_with_incorrect_checksum_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -441,7 +444,7 @@ async fn fuzzing_incorrect_checksum_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -490,7 +493,7 @@ async fn fuzzing_version_with_incorrect_checksum_during_handshake_responder_side
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -525,7 +528,7 @@ async fn fuzzing_incorrect_checksum_during_handshake_responder_side() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -575,7 +578,7 @@ async fn fuzzing_version_with_incorrect_length_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -610,7 +613,7 @@ async fn fuzzing_incorrect_length_pre_handshake() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -659,7 +662,7 @@ async fn fuzzing_version_with_incorrect_length_during_handshake_responder_side()
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 
@@ -694,7 +697,7 @@ async fn fuzzing_incorrect_length_during_handshake_responder_side() {
     let (zig, node_meta) = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.start_waits_for_connection(zig.new_local_addr())
+    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
         .start()
         .await;
 


### PR DESCRIPTION
Refactors the `node.wait_for_connection` to `node.initial_action(Action)` where `Action` can be one of

1. None
2. Wait for connection
3. Seed with genesis blocks

One alternative is to create a helper function instead. I decided it would be better to have it as part of the node startup since the procedure requires that no other data has been sent to the node yet.

I'm open to changing this though.