### PR TITLE
ref: remove docker configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ziggurat is configured with a `config.toml` file in the root.
 ```toml
 kind = "zebra"
 path = "path/to/zebra/repo"
-start_command = "cargo +stable r -- --config node.toml --verbose start"
+start_command = "cargo +stable r -- --config zebra.toml --verbose start"
 
 # kind = "zcashd"
 # path = "path/to/zcash/repo"

--- a/README.md
+++ b/README.md
@@ -21,39 +21,20 @@ and [zebra](https://github.com/ZcashFoundation/zebra) devs with this reliable fo
 Ziggurat is configured with a `config.toml` file in the root.
 
 ```toml
-[node]
 kind = "zebra"
 path = "path/to/zebra/repo"
 start_command = "cargo +stable r -- --config node.toml --verbose start"
 
-# For dockerized zcashd:
-# local_ip = "0.0.0.0"
-# [node]
 # kind = "zcashd"
-# path = "/path/to/zcashd/configfile/usually/home/dir"
-# start_command = "docker start my_zcashd"
-# stop_command = "docker stop my_zcashd"
-# local_addr = "0.0.0.0:8080"
-# external_addr = "0.0.0.0:8080"
-# peer_ip = "host.docker.internal"
+# path = "path/to/zcash/repo"
+# start_command = "./src/zcashd -debug=1 -dnsseed=0 -printtoconsole -logips=1 -listenonion=0 -dns=0 -conf=/path/to/zcash/repo/zcash.conf"
 ```
 
-The networking properties of Ziggurat itself can be set with:
-- `local_ip`: the local ip to use with all Ziggurat spawned listeners. Defaults to localhost.
-
-Additionally, information about the node to be tested can be set under the `[node]` table:
+Information about the node to be tested can be set under the `[node]` table:
 
 - `kind`: one of `zebra` or `zcashd`
-- `path`: absolute path in which to run the start and stop commands, or your zcashd config in the case of dockerized zcashd.
+- `path`: absolute path in which to run the start and stop commands.
 - `start_command`: the command used to start the node (args inline).
-
-and optionally:
-
-- `stop_command`: the command used to stop the node. This may be useful when running e.g. a dockerised instance of the node.
-- `local_addr`: the local address of the node. Defaults to localhost, should be set if the node needs distinct local and external addresses.
-- `external_addr`: the external address of the node. Defaults to localhost.
-- `peer_ip`: the ip/dns name the node can reach the peers through.
-
 
 When starting the node, this information and the configuration provided in the tests will be written to a configuration file compatible with and read by the node under test.
 

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -105,8 +105,6 @@ impl NodeMetaData {
     }
 }
 
-// ZEBRA CONFIG FILE
-
 /// Convenience struct for writing a zebra compatible configuration file.
 #[derive(Serialize)]
 pub(super) struct ZebraConfigFile {
@@ -165,8 +163,6 @@ struct StateConfig {
 struct TracingConfig {
     filter: Option<String>,
 }
-
-// ZCASHD CONFIG FILE
 
 /// Convenience struct for writing a zcashd compatible configuration file.
 pub(super) struct ZcashdConfigFile;

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -104,18 +104,6 @@ pub struct NodeMetaData {
     pub(super) start_command: OsString,
     /// The args to run with the start command.
     pub(super) start_args: Vec<OsString>,
-    /// The command to run when stopping a node.
-    pub(super) stop_command: Option<OsString>,
-    /// The args to run with the stop command.
-    pub(super) stop_args: Option<Vec<OsString>>,
-
-    /// The address the node should be run on.
-    pub(super) local_addr: SocketAddr,
-    /// The address peers can expect the node to be reachable on (this may differ from the
-    /// `local_addr` when using e.g. Docker).
-    pub(super) external_addr: SocketAddr,
-    /// The ip/dns name the node should expect peers to be reachable on.
-    pub(super) peer_ip: String,
 }
 
 impl NodeMetaData {
@@ -127,38 +115,11 @@ impl NodeMetaData {
         let mut start_args = args_from(&meta_file.start_command);
         let start_command = start_args.remove(0);
 
-        // Default to None.
-        let mut stop_args = None;
-        let mut stop_command = None;
-
-        // Set stop command if provided.
-        if let Some(command) = meta_file.stop_command {
-            let mut args = args_from(&command);
-            stop_command = Some(args.remove(0));
-            stop_args = Some(args);
-        }
-
-        // Default to localhost if no value is present in file.
-        let local_addr = meta_file
-            .local_addr
-            .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), NODE_PORT));
-        let external_addr = meta_file
-            .external_addr
-            .unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), NODE_PORT));
-        let peer_ip = meta_file
-            .peer_ip
-            .unwrap_or_else(|| Ipv4Addr::LOCALHOST.to_string());
-
         Self {
             kind: meta_file.kind,
             path: meta_file.path,
             start_command,
             start_args,
-            stop_command,
-            stop_args,
-            local_addr,
-            external_addr,
-            peer_ip,
         }
     }
 }
@@ -170,10 +131,6 @@ struct MetaDataFile {
     kind: NodeKind,
     path: PathBuf,
     start_command: String,
-    stop_command: Option<String>,
-    local_addr: Option<SocketAddr>,
-    external_addr: Option<SocketAddr>,
-    peer_ip: Option<String>,
 }
 
 // ZEBRA CONFIG FILE

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -12,6 +12,7 @@ use std::{
 use crate::setup::node::Action;
 
 const CONFIG: &str = "config.toml";
+const DEFAULT_PORT: u16 = 8080;
 
 /// Returns a new address suitable for starting a local listener.
 pub fn new_local_addr() -> SocketAddr {
@@ -47,8 +48,12 @@ pub(super) struct NodeConfig {
 
 impl NodeConfig {
     pub(super) fn new() -> Self {
+        // Set the port explicitly.
+        let mut local_addr = new_local_addr();
+        local_addr.set_port(DEFAULT_PORT);
+
         Self {
-            local_addr: new_local_addr(),
+            local_addr,
             initial_peers: HashSet::new(),
             max_peers: 50,
             log_to_stdout: false,

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -11,16 +11,7 @@ use std::{
 
 use crate::setup::node::Action;
 
-/// Reads the contents of Ziggurat's configuration file.
-pub fn read_config_file() -> NodeMetaData {
-    let path = &env::current_dir().unwrap().join("config.toml");
-    let config_string = fs::read_to_string(path).unwrap();
-    let config_file: ConfigFile = toml::from_str(&config_string).unwrap();
-
-    let node_meta = NodeMetaData::new(config_file);
-
-    node_meta
-}
+const CONFIG: &str = "config.toml";
 
 /// Returns a new address suitable for starting a local listener.
 pub fn new_local_addr() -> SocketAddr {
@@ -88,17 +79,21 @@ pub struct NodeMetaData {
 }
 
 impl NodeMetaData {
-    fn new(meta_file: ConfigFile) -> Self {
+    pub(super) fn new() -> Self {
+        let path = &env::current_dir().unwrap().join(CONFIG);
+        let config_string = fs::read_to_string(path).unwrap();
+        let config_file: ConfigFile = toml::from_str(&config_string).unwrap();
+
         let args_from = |command: &str| -> Vec<OsString> {
             command.split_whitespace().map(OsString::from).collect()
         };
 
-        let mut start_args = args_from(&meta_file.start_command);
+        let mut start_args = args_from(&config_file.start_command);
         let start_command = start_args.remove(0);
 
         Self {
-            kind: meta_file.kind,
-            path: meta_file.path,
+            kind: config_file.kind,
+            path: config_file.path,
             start_command,
             start_args,
         }

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -14,36 +14,19 @@ use crate::setup::node::Action;
 const NODE_PORT: u16 = 8080;
 
 /// Reads the contents of Ziggurat's configuration file.
-pub fn read_config_file() -> (Config, NodeMetaData) {
+pub fn read_config_file() -> NodeMetaData {
     let path = &env::current_dir().unwrap().join("config.toml");
     let config_string = fs::read_to_string(path).unwrap();
     let config_file: ConfigFile = toml::from_str(&config_string).unwrap();
 
-    let config = Config::new(config_file.local_ip);
     let node_meta = NodeMetaData::new(config_file.node);
 
-    (config, node_meta)
+    node_meta
 }
 
-/// Ziggurat configuration read from the `config.toml` file.
-pub struct Config {
-    /// The local address to be used by Ziggurat listeners.
-    local_ip: IpAddr,
-}
-
-impl Config {
-    fn new(local_ip: Option<String>) -> Self {
-        let ip = local_ip.map_or(IpAddr::V4(Ipv4Addr::LOCALHOST), |ip| {
-            ip.parse().expect("couldn't parse string into ip address")
-        });
-
-        Self { local_ip: ip }
-    }
-
-    /// Returns a new address suitable for starting a local listener.
-    pub fn new_local_addr(&self) -> SocketAddr {
-        SocketAddr::new(self.local_ip, 0)
-    }
+/// Returns a new address suitable for starting a local listener.
+pub fn new_local_addr() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0)
 }
 
 /// Convenience struct for reading Ziggurat's configuration file.
@@ -73,9 +56,9 @@ pub(super) struct NodeConfig {
 }
 
 impl NodeConfig {
-    pub(super) fn new(local_addr: SocketAddr) -> Self {
+    pub(super) fn new() -> Self {
         Self {
-            local_addr,
+            local_addr: new_local_addr(),
             initial_peers: HashSet::new(),
             max_peers: 50,
             log_to_stdout: false,

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -52,18 +52,18 @@ pub struct Node {
     process: Option<Child>,
 }
 
-impl Node {
-    /// Creates a new [`Node`] instance from [`NodeMetaData`].
+impl Default for Node {
+    /// Creates a new [`Node`] instance.
     ///
     /// Once created, it can be configured with calls to [`initial_peers`], [`max_peers`] and [`log_to_stdout`].
     ///
     /// [`Node`]: struct@Node
     /// [`NodeMetaData`]: struct@crate::setup::config::NodeMetaData
-    /// [`initial_peers`]: methode@Node::initial_peers
-    /// [`max_peers`]: methode@Node::max_peers
+    /// [`initial_peers`]: method@Node::initial_peers
+    /// [`max_peers`]: method@Node::max_peers
     /// [`log_to_stdout`]: method@Node::log_to_stdout
-    pub fn new() -> Self {
-        // Config (to be written to node configuration file) sets a random local address.
+    fn default() -> Self {
+        // Config (to be written to node configuration file).
         let config = NodeConfig::new();
         let meta = NodeMetaData::new();
 
@@ -73,7 +73,9 @@ impl Node {
             process: None,
         }
     }
+}
 
+impl Node {
     /// Returns the (external) address of the node.
     pub fn addr(&self) -> SocketAddr {
         self.config.local_addr

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -17,6 +17,9 @@ use tokio::{
 
 use std::{fs, net::SocketAddr, process::Stdio};
 
+const ZEBRA_CONFIG: &str = "zebra.toml";
+const ZCASHD_CONFIG: &str = "zcash.conf";
+
 pub enum Action {
     /// Performs no action
     None,
@@ -59,9 +62,10 @@ impl Node {
     /// [`initial_peers`]: methode@Node::initial_peers
     /// [`max_peers`]: methode@Node::max_peers
     /// [`log_to_stdout`]: method@Node::log_to_stdout
-    pub fn new(meta: NodeMetaData) -> Self {
+    pub fn new() -> Self {
         // Config (to be written to node configuration file) sets a random local address.
         let config = NodeConfig::new();
+        let meta = NodeMetaData::new();
 
         Self {
             config,
@@ -237,7 +241,7 @@ impl Node {
         }
     }
 
-    // FIXME: move to a `Drop` impl on `Node`.
+    // FIXME: move to a `Drop` impl on `Node`?
     /// Stops the node instance.
     ///
     /// The stop command will only be run if provided in the `config.toml` file as it may not be
@@ -261,8 +265,8 @@ impl Node {
 
     fn config_filepath(&self) -> std::path::PathBuf {
         match self.meta.kind {
-            NodeKind::Zebra => self.meta.path.join("node.toml"),
-            NodeKind::Zcashd => self.meta.path.join("zcash.conf"),
+            NodeKind::Zebra => self.meta.path.join(ZEBRA_CONFIG),
+            NodeKind::Zcashd => self.meta.path.join(ZCASHD_CONFIG),
         }
     }
 

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -40,11 +40,6 @@ pub enum Action {
 
 /// Represents an instance of a node, its configuration and setup/teardown intricacies.
 pub struct Node {
-    /// The (external) address of a node.
-    ///
-    /// Nodes can have a local address distinct from the external address at
-    /// which it is reachable (e.g. docker).
-    addr: SocketAddr,
     /// Configuration definable in tests and written to the node's configuration file on start.
     config: NodeConfig,
     /// Type, path to binary, various commands for starting, stopping, cleanup, network
@@ -65,13 +60,10 @@ impl Node {
     /// [`max_peers`]: methode@Node::max_peers
     /// [`log_to_stdout`]: method@Node::log_to_stdout
     pub fn new(meta: NodeMetaData) -> Self {
-        // Config (to be written to node configuration file) sets the configured `local_ip`.
-        let config = NodeConfig::new(meta.local_addr);
+        // Config (to be written to node configuration file) sets a random local address.
+        let config = NodeConfig::new();
 
-        // The node instance gets a node address which may differ from the `local_ip`.
         Self {
-            // TODO: select random port to support multiple nodes.
-            addr: meta.external_addr,
             config,
             meta,
             process: None,
@@ -80,18 +72,15 @@ impl Node {
 
     /// Returns the (external) address of the node.
     pub fn addr(&self) -> SocketAddr {
-        self.addr
+        self.config.local_addr
     }
 
     /// Sets the initial peers (ports only) for the node.
     ///
     /// The ip used to construct the addresses can be optionally set in the configuration file and
     /// otherwise defaults to localhost.
-    pub fn initial_peers(&mut self, peers: Vec<u16>) -> &mut Self {
-        self.config.initial_peers = peers
-            .iter()
-            .map(|port| format!("{}:{}", self.meta.peer_ip, port))
-            .collect();
+    pub fn initial_peers(&mut self, peers: Vec<SocketAddr>) -> &mut Self {
+        self.config.initial_peers = peers.iter().map(|addr| format!("{}", addr)).collect();
 
         self
     }
@@ -132,11 +121,9 @@ impl Node {
                 block_count: _,
             } => {
                 let bound_listener = TcpListener::bind(addr).await.unwrap();
-                self.config.initial_peers.insert(format!(
-                    "{}:{}",
-                    self.meta.peer_ip,
-                    bound_listener.local_addr().unwrap().port()
-                ));
+                self.config
+                    .initial_peers
+                    .insert(format!("{}", bound_listener.local_addr().unwrap()));
                 Some(bound_listener)
             }
         };
@@ -250,35 +237,14 @@ impl Node {
         }
     }
 
+    // FIXME: move to a `Drop` impl on `Node`.
     /// Stops the node instance.
     ///
     /// The stop command will only be run if provided in the `config.toml` file as it may not be
     /// necessary to shutdown a node (killing the process is sometimes sufficient).
     pub async fn stop(&mut self) {
         let mut child = self.process.take().unwrap();
-        let stdout = match self.config.log_to_stdout {
-            true => Stdio::inherit(),
-            false => Stdio::null(),
-        };
-
-        // Simply kill the process if no stop command is provided. If it is, run it under the
-        // assumption the process has already exited.
-        match (
-            self.meta.stop_command.as_ref(),
-            self.meta.stop_args.as_ref(),
-        ) {
-            (Some(stop_command), Some(stop_args)) => {
-                Command::new(stop_command)
-                    .current_dir(&self.meta.path)
-                    .args(stop_args)
-                    .stdin(Stdio::null())
-                    .stdout(stdout)
-                    .status()
-                    .await
-                    .expect("failed to run stop command");
-            }
-            _ => child.kill().await.expect("failed to kill process"),
-        }
+        child.kill().await.expect("failed to kill process");
 
         self.cleanup();
     }

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -5,7 +5,7 @@ use crate::{
         payload::{block::Headers, Addr, Nonce, Version},
     },
     setup::{
-        config::read_config_file,
+        config::{new_local_addr, read_config_file},
         node::{Action, Node},
     },
 };
@@ -16,10 +16,10 @@ use tokio::net::{TcpListener, TcpStream};
 async fn handshake_responder_side() {
     // ZG-CONFORMANCE-001
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -49,13 +49,13 @@ async fn handshake_responder_side() {
 async fn handshake_initiator_side() {
     // ZG-CONFORMANCE-002
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
-    let listener = TcpListener::bind(zig.new_local_addr()).await.unwrap();
+    let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
     // Create a node and set the listener as an initial peer.
     let mut node = Node::new(node_meta);
-    node.initial_peers(vec![listener.local_addr().unwrap().port()])
+    node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
 
@@ -129,10 +129,10 @@ async fn reject_non_version_before_handshake() {
         // Message::NotFound(Inv));
     ];
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -221,20 +221,20 @@ async fn reject_non_version_replies_to_version() {
         // Message::NotFound(Inv));
     ];
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     // Create and bind TCP listeners (so we have the ports ready for instantiating the node)
     let mut listeners = Vec::with_capacity(test_messages.len());
     for _ in test_messages.iter() {
-        listeners.push(TcpListener::bind(zig.new_local_addr()).await.unwrap());
+        listeners.push(TcpListener::bind(new_local_addr()).await.unwrap());
     }
 
-    let ports = listeners
+    let addrs = listeners
         .iter()
-        .map(|listener| listener.local_addr().unwrap().port())
+        .map(|listener| listener.local_addr().unwrap())
         .collect();
     let mut node = Node::new(node_meta);
-    node.initial_peers(ports);
+    node.initial_peers(addrs);
 
     let mut handles = Vec::with_capacity(test_messages.len());
 
@@ -319,20 +319,20 @@ async fn reject_non_verack_replies_to_verack() {
         // Message::NotFound(Inv)),
     ];
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     // Create and bind TCP listeners (so we have the ports ready for instantiating the node)
     let mut listeners = Vec::with_capacity(test_messages.len());
     for _ in test_messages.iter() {
-        listeners.push(TcpListener::bind(zig.new_local_addr()).await.unwrap());
+        listeners.push(TcpListener::bind(new_local_addr()).await.unwrap());
     }
 
-    let ports = listeners
+    let addrs = listeners
         .iter()
-        .map(|listener| listener.local_addr().unwrap().port())
+        .map(|listener| listener.local_addr().unwrap())
         .collect();
     let mut node = Node::new(node_meta);
-    node.initial_peers(ports);
+    node.initial_peers(addrs);
 
     let mut handles = Vec::with_capacity(test_messages.len());
 
@@ -395,11 +395,11 @@ async fn reject_version_reusing_nonce() {
     // 2. Send back version with same nonce
     // 3. Connection should be terminated
 
-    let (zig, node_meta) = read_config_file();
-    let listener = TcpListener::bind(zig.new_local_addr()).await.unwrap();
+    let node_meta = read_config_file();
+    let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
     let mut node = Node::new(node_meta);
-    node.initial_peers(vec![listener.local_addr().unwrap().port()])
+    node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
 
@@ -466,11 +466,11 @@ async fn reject_obsolete_versions() {
     //      3. Node sends `verack`
     //      4. Node terminates the connection
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
     let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -5,7 +5,7 @@ use crate::{
         payload::{block::Headers, Addr, Nonce, Version},
     },
     setup::{
-        config::{new_local_addr, read_config_file},
+        config::new_local_addr,
         node::{Action, Node},
     },
 };
@@ -16,9 +16,7 @@ use tokio::net::{TcpListener, TcpStream};
 async fn handshake_responder_side() {
     // ZG-CONFORMANCE-001
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -49,12 +47,10 @@ async fn handshake_responder_side() {
 async fn handshake_initiator_side() {
     // ZG-CONFORMANCE-002
 
-    let node_meta = read_config_file();
-
     let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
     // Create a node and set the listener as an initial peer.
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
@@ -129,9 +125,7 @@ async fn reject_non_version_before_handshake() {
         // Message::NotFound(Inv));
     ];
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -221,8 +215,6 @@ async fn reject_non_version_replies_to_version() {
         // Message::NotFound(Inv));
     ];
 
-    let node_meta = read_config_file();
-
     // Create and bind TCP listeners (so we have the ports ready for instantiating the node)
     let mut listeners = Vec::with_capacity(test_messages.len());
     for _ in test_messages.iter() {
@@ -233,7 +225,7 @@ async fn reject_non_version_replies_to_version() {
         .iter()
         .map(|listener| listener.local_addr().unwrap())
         .collect();
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_peers(addrs);
 
     let mut handles = Vec::with_capacity(test_messages.len());
@@ -319,8 +311,6 @@ async fn reject_non_verack_replies_to_verack() {
         // Message::NotFound(Inv)),
     ];
 
-    let node_meta = read_config_file();
-
     // Create and bind TCP listeners (so we have the ports ready for instantiating the node)
     let mut listeners = Vec::with_capacity(test_messages.len());
     for _ in test_messages.iter() {
@@ -331,7 +321,7 @@ async fn reject_non_verack_replies_to_verack() {
         .iter()
         .map(|listener| listener.local_addr().unwrap())
         .collect();
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_peers(addrs);
 
     let mut handles = Vec::with_capacity(test_messages.len());
@@ -395,10 +385,9 @@ async fn reject_version_reusing_nonce() {
     // 2. Send back version with same nonce
     // 3. Connection should be terminated
 
-    let node_meta = read_config_file();
     let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
@@ -466,10 +455,9 @@ async fn reject_obsolete_versions() {
     //      3. Node sends `verack`
     //      4. Node terminates the connection
 
-    let node_meta = read_config_file();
     let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -16,7 +16,7 @@ use tokio::net::{TcpListener, TcpStream};
 async fn handshake_responder_side() {
     // ZG-CONFORMANCE-001
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -50,7 +50,7 @@ async fn handshake_initiator_side() {
     let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
     // Create a node and set the listener as an initial peer.
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
@@ -125,7 +125,7 @@ async fn reject_non_version_before_handshake() {
         // Message::NotFound(Inv));
     ];
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -225,7 +225,7 @@ async fn reject_non_version_replies_to_version() {
         .iter()
         .map(|listener| listener.local_addr().unwrap())
         .collect();
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_peers(addrs);
 
     let mut handles = Vec::with_capacity(test_messages.len());
@@ -321,7 +321,7 @@ async fn reject_non_verack_replies_to_verack() {
         .iter()
         .map(|listener| listener.local_addr().unwrap())
         .collect();
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_peers(addrs);
 
     let mut handles = Vec::with_capacity(test_messages.len());
@@ -387,7 +387,7 @@ async fn reject_version_reusing_nonce() {
 
     let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
@@ -457,7 +457,7 @@ async fn reject_obsolete_versions() {
 
     let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -11,7 +11,7 @@ use crate::{
         },
     },
     setup::{
-        config::{new_local_addr, read_config_file},
+        config::new_local_addr,
         node::{Action, Node},
     },
     wait_until,
@@ -24,12 +24,10 @@ use tokio::{
 
 #[tokio::test]
 async fn ping_pong() {
-    let node_meta = read_config_file();
-
     let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
     // Create a node and set the listener as an initial peer.
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
@@ -98,9 +96,7 @@ async fn reject_invalid_messages() {
     //  Zebra:
     //      Both Version and Verack result in a terminated connection
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -149,12 +145,10 @@ async fn ignores_unsolicited_responses() {
     //      2. Send a ping request
     //      3. Receive a pong response
 
-    let node_meta = read_config_file();
-
     let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
     // Create a node and set the listener as an initial peer.
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
@@ -221,8 +215,6 @@ async fn eagerly_crawls_network_for_peers() {
     //          If we do not keep responding, then the peer connections take really long to establish,
     //          sometimes even spuriously failing the test completely.
 
-    let node_meta = read_config_file();
-
     // create tcp listeners for peer set (port is only assigned on tcp bind)
     let mut listeners = Vec::new();
     for _ in 0u8..5 {
@@ -236,7 +228,7 @@ async fn eagerly_crawls_network_for_peers() {
         .collect::<Vec<_>>();
 
     // start the node
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -335,10 +327,8 @@ async fn correctly_lists_peers() {
     //  zebra:  Infinitely spams `GetAddr` and `GetData`. Can be coaxed into responding correctly if
     //          all its peer connections have responded to `GetAddr` with a non-empty list.
 
-    let node_meta = read_config_file();
-
     // Create a node and main connection
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -519,10 +509,8 @@ async fn correctly_lists_blocks() {
     //
     //  zebra: does not support seeding as yet, and therefore cannot perform this test.
 
-    let node_meta = read_config_file();
-
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::SeedWithTestnetBlocks {
         socket_addr: new_local_addr(),
         block_count: 3,
@@ -638,10 +626,8 @@ async fn get_data_blocks() {
     //
     //  zebra: does not support seeding as yet, and therefore cannot perform this test.
 
-    let node_meta = read_config_file();
-
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::SeedWithTestnetBlocks {
         socket_addr: new_local_addr(),
         block_count: 3,
@@ -721,9 +707,7 @@ async fn get_data_blocks() {
 
 #[allow(dead_code)]
 async fn unsolicitation_listener() {
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.start().await;
 
     let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -399,12 +399,10 @@ async fn get_blocks() {
     // Note: zcashd also excludes the `stop_hash` from the range, whereas the spec states that it should be inclusive.
     //       We are taking current behaviour as correct.
 
-    let (zig, node_meta) = read_config_file();
-
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::SeedWithTestnetBlocks {
-        socket_addr: zig.new_local_addr(),
+        socket_addr: new_local_addr(),
         block_count: 3,
     })
     .log_to_stdout(true)

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -27,7 +27,7 @@ async fn ping_pong() {
     let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
     // Create a node and set the listener as an initial peer.
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
@@ -96,7 +96,7 @@ async fn reject_invalid_messages() {
     //  Zebra:
     //      Both Version and Verack result in a terminated connection
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -148,7 +148,7 @@ async fn ignores_unsolicited_responses() {
     let listener = TcpListener::bind(new_local_addr()).await.unwrap();
 
     // Create a node and set the listener as an initial peer.
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_peers(vec![listener.local_addr().unwrap()])
         .start()
         .await;
@@ -228,7 +228,7 @@ async fn eagerly_crawls_network_for_peers() {
         .collect::<Vec<_>>();
 
     // start the node
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -328,7 +328,7 @@ async fn correctly_lists_peers() {
     //          all its peer connections have responded to `GetAddr` with a non-empty list.
 
     // Create a node and main connection
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -400,7 +400,7 @@ async fn get_blocks() {
     //       We are taking current behaviour as correct.
 
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks {
         socket_addr: new_local_addr(),
         block_count: 3,
@@ -508,7 +508,7 @@ async fn correctly_lists_blocks() {
     //  zebra: does not support seeding as yet, and therefore cannot perform this test.
 
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks {
         socket_addr: new_local_addr(),
         block_count: 3,
@@ -625,7 +625,7 @@ async fn get_data_blocks() {
     //  zebra: does not support seeding as yet, and therefore cannot perform this test.
 
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks {
         socket_addr: new_local_addr(),
         block_count: 3,
@@ -705,7 +705,7 @@ async fn get_data_blocks() {
 
 #[allow(dead_code)]
 async fn unsolicitation_listener() {
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.start().await;
 
     let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -17,7 +17,7 @@ use crate::{
         payload::{block::Headers, Addr, Nonce, Version},
     },
     setup::{
-        config::read_config_file,
+        config::{new_local_addr, read_config_file},
         node::{Action, Node},
     },
 };
@@ -43,10 +43,10 @@ async fn fuzzing_zeroes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -70,10 +70,10 @@ async fn fuzzing_zeroes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -99,10 +99,10 @@ async fn fuzzing_random_bytes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -126,10 +126,10 @@ async fn fuzzing_random_bytes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -173,10 +173,10 @@ async fn fuzzing_metadata_compliant_random_bytes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, commands);
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -219,10 +219,10 @@ async fn fuzzing_metadata_compliant_random_bytes_during_handshake_responder_side
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, commands);
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -254,10 +254,10 @@ async fn fuzzing_slightly_corrupted_version_pre_handshake() {
     // which indicates the message was recognised as invalid).
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -288,10 +288,10 @@ async fn fuzzing_slightly_corrupted_version_during_handshake_responder_side() {
     // zcashd: logs suggest the message was ignored but the node doesn't disconnect.
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -337,10 +337,10 @@ async fn fuzzing_slightly_corrupted_messages_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, test_messages);
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -379,10 +379,10 @@ async fn fuzzing_slightly_corrupted_messages_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, test_messages);
 
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -406,10 +406,10 @@ async fn fuzzing_version_with_incorrect_checksum_pre_handshake() {
     // zcashd: log suggests messages was ignored, doesn't disconnect.
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -441,10 +441,10 @@ async fn fuzzing_incorrect_checksum_pre_handshake() {
     // zcashd: ignores the messages but doesn't disconnect (logs show a `CHECKSUM ERROR`).
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -490,10 +490,10 @@ async fn fuzzing_version_with_incorrect_checksum_during_handshake_responder_side
     // disconnect.
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -525,10 +525,10 @@ async fn fuzzing_incorrect_checksum_during_handshake_responder_side() {
     // zcashd: logs indicate message was ignored, doesn't disconnect.
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -575,10 +575,10 @@ async fn fuzzing_version_with_incorrect_length_pre_handshake() {
     // zcashd: disconnects.
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -610,10 +610,10 @@ async fn fuzzing_incorrect_length_pre_handshake() {
     // zcashd: disconnects.
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -659,10 +659,10 @@ async fn fuzzing_version_with_incorrect_length_during_handshake_responder_side()
     // zcashd: disconnects (after sending verack, ping, getheaders).
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 
@@ -694,10 +694,10 @@ async fn fuzzing_incorrect_length_during_handshake_responder_side() {
     // zcashd: disconnects (after sending verack, ping, getheaders).
 
     let mut rng = seeded_rng();
-    let (zig, node_meta) = read_config_file();
+    let node_meta = read_config_file();
 
     let mut node = Node::new(node_meta);
-    node.initial_action(Action::WaitForConnection(zig.new_local_addr()))
+    node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
 

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -17,7 +17,7 @@ use crate::{
         payload::{block::Headers, Addr, Nonce, Version},
     },
     setup::{
-        config::{new_local_addr, read_config_file},
+        config::new_local_addr,
         node::{Action, Node},
     },
 };
@@ -43,9 +43,7 @@ async fn fuzzing_zeroes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -70,9 +68,7 @@ async fn fuzzing_zeroes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -99,9 +95,7 @@ async fn fuzzing_random_bytes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -126,9 +120,7 @@ async fn fuzzing_random_bytes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -173,9 +165,7 @@ async fn fuzzing_metadata_compliant_random_bytes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, commands);
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -219,9 +209,7 @@ async fn fuzzing_metadata_compliant_random_bytes_during_handshake_responder_side
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, commands);
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -254,9 +242,8 @@ async fn fuzzing_slightly_corrupted_version_pre_handshake() {
     // which indicates the message was recognised as invalid).
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -288,9 +275,8 @@ async fn fuzzing_slightly_corrupted_version_during_handshake_responder_side() {
     // zcashd: logs suggest the message was ignored but the node doesn't disconnect.
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -337,9 +323,7 @@ async fn fuzzing_slightly_corrupted_messages_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, test_messages);
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -379,9 +363,7 @@ async fn fuzzing_slightly_corrupted_messages_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, test_messages);
 
-    let node_meta = read_config_file();
-
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -406,9 +388,8 @@ async fn fuzzing_version_with_incorrect_checksum_pre_handshake() {
     // zcashd: log suggests messages was ignored, doesn't disconnect.
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -441,9 +422,8 @@ async fn fuzzing_incorrect_checksum_pre_handshake() {
     // zcashd: ignores the messages but doesn't disconnect (logs show a `CHECKSUM ERROR`).
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -490,9 +470,8 @@ async fn fuzzing_version_with_incorrect_checksum_during_handshake_responder_side
     // disconnect.
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -525,9 +504,8 @@ async fn fuzzing_incorrect_checksum_during_handshake_responder_side() {
     // zcashd: logs indicate message was ignored, doesn't disconnect.
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -575,9 +553,8 @@ async fn fuzzing_version_with_incorrect_length_pre_handshake() {
     // zcashd: disconnects.
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -610,9 +587,8 @@ async fn fuzzing_incorrect_length_pre_handshake() {
     // zcashd: disconnects.
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -659,9 +635,8 @@ async fn fuzzing_version_with_incorrect_length_during_handshake_responder_side()
     // zcashd: disconnects (after sending verack, ping, getheaders).
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -694,9 +669,8 @@ async fn fuzzing_incorrect_length_during_handshake_responder_side() {
     // zcashd: disconnects (after sending verack, ping, getheaders).
 
     let mut rng = seeded_rng();
-    let node_meta = read_config_file();
 
-    let mut node = Node::new(node_meta);
+    let mut node = Node::new();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;

--- a/src/tests/resistance/fuzzing.rs
+++ b/src/tests/resistance/fuzzing.rs
@@ -43,7 +43,7 @@ async fn fuzzing_zeroes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -68,7 +68,7 @@ async fn fuzzing_zeroes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -95,7 +95,7 @@ async fn fuzzing_random_bytes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -120,7 +120,7 @@ async fn fuzzing_random_bytes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -165,7 +165,7 @@ async fn fuzzing_metadata_compliant_random_bytes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, commands);
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -209,7 +209,7 @@ async fn fuzzing_metadata_compliant_random_bytes_during_handshake_responder_side
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, commands);
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -243,7 +243,7 @@ async fn fuzzing_slightly_corrupted_version_pre_handshake() {
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -276,7 +276,7 @@ async fn fuzzing_slightly_corrupted_version_during_handshake_responder_side() {
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -323,7 +323,7 @@ async fn fuzzing_slightly_corrupted_messages_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, test_messages);
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -363,7 +363,7 @@ async fn fuzzing_slightly_corrupted_messages_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, test_messages);
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -389,7 +389,7 @@ async fn fuzzing_version_with_incorrect_checksum_pre_handshake() {
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -423,7 +423,7 @@ async fn fuzzing_incorrect_checksum_pre_handshake() {
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -471,7 +471,7 @@ async fn fuzzing_version_with_incorrect_checksum_during_handshake_responder_side
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -505,7 +505,7 @@ async fn fuzzing_incorrect_checksum_during_handshake_responder_side() {
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -554,7 +554,7 @@ async fn fuzzing_version_with_incorrect_length_pre_handshake() {
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -588,7 +588,7 @@ async fn fuzzing_incorrect_length_pre_handshake() {
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -636,7 +636,7 @@ async fn fuzzing_version_with_incorrect_length_during_handshake_responder_side()
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;
@@ -670,7 +670,7 @@ async fn fuzzing_incorrect_length_during_handshake_responder_side() {
 
     let mut rng = seeded_rng();
 
-    let mut node = Node::new();
+    let mut node: Node = Default::default();
     node.initial_action(Action::WaitForConnection(new_local_addr()))
         .start()
         .await;


### PR DESCRIPTION
This PR: 
- removes docker configuration (see readme for new format),
- removes `read_config_file` (absracted),
- changes `initial_peers` to accept full addresses instead of just the port,
- exposes `config::new_local_addr` as a convenience function,
- introduces constants for configuration file names.