### PR TITLE
feat: add caching to CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: test
           args: -- --ignored
+
 
   clippy:
     runs-on: ubuntu-latest
@@ -31,10 +33,12 @@ jobs:
           toolchain: nightly
           override: true
           components: clippy
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
+
 
   rustfmt:
     runs-on: ubuntu-latest
@@ -46,6 +50,7 @@ jobs:
           toolchain: nightly
           override: true
           components: rustfmt
+      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           command: fmt


### PR DESCRIPTION
Effectively reduces each jobs `cargo action` section from 60secs+ to <10secs (barring dependency changes).

(Not sure we actually want this - I just wanted to see the impact)