### PR TITLE
conformance test 011

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Quick overview of the current status, providing implementation progress and test
 | [![conf_008](https://img.shields.io/badge/008-██████████-red)     ](SPEC.md#ZG-CONFORMANCE-008)| :warning: Need to confirm expected behaviour with zcash.
 | [![conf_009](https://img.shields.io/badge/009-██████████-green)   ](SPEC.md#ZG-CONFORMANCE-009)|
 | [![conf_010](https://img.shields.io/badge/010-██████████-red)     ](SPEC.md#ZG-CONFORMANCE-010)|
-| [![conf_011](https://img.shields.io/badge/011-░░░░░░░░░░-inactive)](SPEC.md#ZG-CONFORMANCE-011)|
+| [![conf_011](https://img.shields.io/badge/011-██████████-red)     ](SPEC.md#ZG-CONFORMANCE-011)|
 | [![conf_012](https://img.shields.io/badge/012-██████████-red)     ](SPEC.md#ZG-CONFORMANCE-012)| :warning: Zcashd node config requires investigation.
 | [![conf_013](https://img.shields.io/badge/013-██████████-red)     ](SPEC.md#ZG-CONFORMANCE-013)| :warning: Need to confirm expected behaviour with zcash.
 | [![conf_014](https://img.shields.io/badge/014-░░░░░░░░░░-inactive)](SPEC.md#ZG-CONFORMANCE-014)|

--- a/src/protocol/payload/addr.rs
+++ b/src/protocol/payload/addr.rs
@@ -58,6 +58,11 @@ impl NetworkAddr {
         }
     }
 
+    pub fn with_last_seen(mut self, last_seen: Option<DateTime<Utc>>) -> Self {
+        self.last_seen = last_seen;
+        self
+    }
+
     pub(super) fn encode_without_timestamp(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
         buffer.write_all(&self.services.to_le_bytes())?;
 


### PR DESCRIPTION
Note that the test case for `Addr` without a timestamp cannot be run with the code as is. This is due to the test case basically requiring a malformed struct which `encode` rejects / panics on.