### PR TITLE
ref: handshake tests with synthetic nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ histogram = "0.6.9"
 home = "0.5.3"
 lazy_static = "1.4.0"
 parking_lot = "0.11.1"
-pea2pea = "0.20.1"
+pea2pea = "0.20.2"
 rand = "0.8.3"
 rand_chacha = "0.3.0"
 sha2 = "0.9.3"
@@ -30,5 +30,7 @@ features = [ "derive" ]
 version = "1"
 features = [ "full" ]
 
-
+[dependencies.tracing-subscriber]
+version = "0.2.18"
+features = [ "env-filter", "fmt" ]
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Ziggurat currently uses rust's standard test runner, a simple `cargo test -- --t
 
 ## Test Status
 
-Short overview of test cases and their current status.
+Short overview of test cases and their current status. In case of failure, the behaviour observed for `zebra` and `zcashd` is usually documented in the test case.
 
 | Legend | |
 | :----: |--|
@@ -61,7 +61,7 @@ Short overview of test cases and their current status.
 | [003](SPEC.md#ZG-CONFORMANCE-003) |   ✓    |   ✖   |
 | [004](SPEC.md#ZG-CONFORMANCE-004) |   ✓    |   ✖   |
 | [005](SPEC.md#ZG-CONFORMANCE-005) |   ✖    |   ✖   |
-| [006](SPEC.md#ZG-CONFORMANCE-006) |   ✓    |   ✓   |
+| [006](SPEC.md#ZG-CONFORMANCE-006) |   ✖    |   ✖   |
 | [007](SPEC.md#ZG-CONFORMANCE-007) |   ✖    |   ✖   |
 | [008](SPEC.md#ZG-CONFORMANCE-008) |   ✖    |   ✖   | ⚠ filter's may need work (malformed), ⚠ require zcashd feedback
 | [009](SPEC.md#ZG-CONFORMANCE-009) |   ✓    |   ✓   |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Short overview of test cases and their current status.
 | [001](SPEC.md#ZG-CONFORMANCE-001) |   ✓    |   ✓   |
 | [002](SPEC.md#ZG-CONFORMANCE-002) |   ✓    |   ✓   |
 | [003](SPEC.md#ZG-CONFORMANCE-003) |   ✓    |   ✖   |
-| [004](SPEC.md#ZG-CONFORMANCE-004) |   ✓    |   ✓   |
+| [004](SPEC.md#ZG-CONFORMANCE-004) |   ✓    |   ✖   |
 | [005](SPEC.md#ZG-CONFORMANCE-005) |   ✖    |   ✖   |
 | [006](SPEC.md#ZG-CONFORMANCE-006) |   ✓    |   ✓   |
 | [007](SPEC.md#ZG-CONFORMANCE-007) |   ✖    |   ✖   |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Short overview of test cases and their current status.
 | :-------------------------------: | :----: | :---: | :--------------------- |
 | [001](SPEC.md#ZG-CONFORMANCE-001) |   ✓    |   ✓   |
 | [002](SPEC.md#ZG-CONFORMANCE-002) |   ✓    |   ✓   |
-| [003](SPEC.md#ZG-CONFORMANCE-003) |   ✓    |   ✓   |
+| [003](SPEC.md#ZG-CONFORMANCE-003) |   ✓    |   ✖   |
 | [004](SPEC.md#ZG-CONFORMANCE-004) |   ✓    |   ✓   |
 | [005](SPEC.md#ZG-CONFORMANCE-005) |   ✖    |   ✖   |
 | [006](SPEC.md#ZG-CONFORMANCE-006) |   ✓    |   ✓   |

--- a/SPEC.md
+++ b/SPEC.md
@@ -124,7 +124,7 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 
     1. The node under test initiates a connection (rpc: `addnode`).
     2. Respond to received `Version` with the node’s nonce.
-    3. Assert the node rejected the connection.
+    3. Assert the node closed the connection.
 
 ### ZG-CONFORMANCE-007
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -111,12 +111,12 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 
 ### ZG-CONFORMANCE-005
 
-    The node rejects non-`Verack` message as a response to initial `Verack` it sent.
+    The node ignores non-`Verack` message as a response to initial `Verack` it sent.
 
     1. The node under test initiates a connection (rpc: `addnode`).
     2. Respond to `Version`, expect `Verack`.
     3. Respond to `Verack` with non-`Verack` messages.
-    4. Assert the node rejected the connection.
+    4. Assert the node ignored the message by completing the handshake.
 
 ### ZG-CONFORMANCE-006
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -99,15 +99,15 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 
     1. Connect to the node under test.
     2. Send non-`Version` messages.
-    3. Verify that this message was ignored by completing the handshake
+    3. Assert the node ignored the message by completing the handshake.
 
 ### ZG-CONFORMANCE-004
 
-    The node rejects non-`Version` messages in response to the initial `Version` it sent.
+    The node ignores non-`Version` messages in response to the initial `Version` it sent.
 
     1. The node under test initiates a connection (rpc: `addnode`).
     2. Respond to `Version` with non-`Version` messages.
-    3. Assert the node rejected the connection.
+    3. Assert the node ignored the message by completing the handshake.
 
 ### ZG-CONFORMANCE-005
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -13,6 +13,15 @@ use tokio::{
 
 use std::{net::SocketAddr, time::Duration};
 
+pub fn enable_tracing() {
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    fmt()
+        .with_test_writer()
+        .with_env_filter(EnvFilter::from_default_env())
+        .init();
+}
+
 /// Waits until an expression is true or times out.
 ///
 /// Uses polling to cut down on time otherwise used by calling `sleep` in tests.

--- a/src/helpers/synthetic_peers.rs
+++ b/src/helpers/synthetic_peers.rs
@@ -69,6 +69,11 @@ impl SyntheticNode {
         })
     }
 
+    /// Returns the listening address of the node.
+    pub fn listening_addr(&self) -> SocketAddr {
+        self.inner_node.node().listening_addr()
+    }
+
     /// Connects to the target address.
     ///
     /// If the handshake protocol is enabled it will be executed as well.
@@ -80,6 +85,10 @@ impl SyntheticNode {
 
     pub fn is_connected(&self, addr: SocketAddr) -> bool {
         self.inner_node.node().is_connected(addr)
+    }
+
+    pub fn num_connected(&self) -> usize {
+        self.inner_node.node().num_connected()
     }
 
     /// Reads a message from the inbound (internal) queue of the node.

--- a/src/helpers/synthetic_peers.rs
+++ b/src/helpers/synthetic_peers.rs
@@ -211,7 +211,7 @@ impl Reading for InnerNode {
         let header_bytes = &buffer[..HEADER_LEN];
         let header = MessageHeader::decode(&mut Cursor::new(header_bytes))?;
 
-        // Check buffer contains the announce message lenght.
+        // Check buffer contains the announced message length.
         if buffer.len() < HEADER_LEN + header.body_length as usize {
             return Err(ErrorKind::InvalidData.into());
         }

--- a/src/helpers/synthetic_peers.rs
+++ b/src/helpers/synthetic_peers.rs
@@ -78,6 +78,10 @@ impl SyntheticNode {
         Ok(())
     }
 
+    pub fn is_connected(&self, addr: SocketAddr) -> bool {
+        self.inner_node.node().is_connected(addr)
+    }
+
     /// Reads a message from the inbound (internal) queue of the node.
     ///
     /// Messages are sent to the queue when unfiltered by the message filter.
@@ -145,7 +149,7 @@ impl Reading for InnerNode {
         buffer: &[u8],
     ) -> Result<Option<(Self::Message, usize)>> {
         // Check buffer contains a full header.
-        if buffer.len() <= HEADER_LEN {
+        if buffer.len() < HEADER_LEN {
             return Ok(None);
         }
 
@@ -154,7 +158,7 @@ impl Reading for InnerNode {
         let header = MessageHeader::decode(&mut Cursor::new(header_bytes))?;
 
         // Check buffer contains the announce message lenght.
-        if buffer.len() <= HEADER_LEN + header.body_length as usize {
+        if buffer.len() < HEADER_LEN + header.body_length as usize {
             return Err(ErrorKind::InvalidData.into());
         }
 

--- a/src/helpers/synthetic_peers.rs
+++ b/src/helpers/synthetic_peers.rs
@@ -242,7 +242,7 @@ impl Writing for InnerNode {
         payload: &[u8],
         buffer: &mut [u8],
     ) -> Result<usize> {
-        buffer[..payload.len()].copy_from_slice(&payload);
+        buffer[..payload.len()].copy_from_slice(payload);
         Ok(payload.len())
     }
 }

--- a/src/protocol/message/filter.rs
+++ b/src/protocol/message/filter.rs
@@ -43,6 +43,12 @@ pub struct MessageFilter {
     logging: bool,
 }
 
+impl Default for MessageFilter {
+    fn default() -> Self {
+        Self::with_all_disabled()
+    }
+}
+
 impl MessageFilter {
     /// Constructs a [MessageFilter] which will filter no messages, and with logging disabled.
     pub fn with_all_disabled() -> Self {

--- a/src/protocol/message/filter.rs
+++ b/src/protocol/message/filter.rs
@@ -43,12 +43,6 @@ pub struct MessageFilter {
     logging: bool,
 }
 
-impl Default for MessageFilter {
-    fn default() -> Self {
-        Self::with_all_disabled()
-    }
-}
-
 impl MessageFilter {
     /// Constructs a [MessageFilter] which will filter no messages, and with logging disabled.
     pub fn with_all_disabled() -> Self {

--- a/src/protocol/message/mod.rs
+++ b/src/protocol/message/mod.rs
@@ -83,68 +83,68 @@ impl Message {
         let header = match self {
             Self::Version(version) => {
                 version.encode(buffer)?;
-                MessageHeader::new(VERSION_COMMAND, &buffer)
+                MessageHeader::new(VERSION_COMMAND, buffer)
             }
-            Self::Verack => MessageHeader::new(VERACK_COMMAND, &buffer),
+            Self::Verack => MessageHeader::new(VERACK_COMMAND, buffer),
             Self::Ping(nonce) => {
                 nonce.encode(buffer)?;
-                MessageHeader::new(PING_COMMAND, &buffer)
+                MessageHeader::new(PING_COMMAND, buffer)
             }
             Self::Pong(nonce) => {
                 nonce.encode(buffer)?;
-                MessageHeader::new(PONG_COMMAND, &buffer)
+                MessageHeader::new(PONG_COMMAND, buffer)
             }
-            Self::GetAddr => MessageHeader::new(GETADDR_COMMAND, &buffer),
+            Self::GetAddr => MessageHeader::new(GETADDR_COMMAND, buffer),
             Self::Addr(addr) => {
                 addr.encode(buffer)?;
-                MessageHeader::new(ADDR_COMMAND, &buffer)
+                MessageHeader::new(ADDR_COMMAND, buffer)
             }
             Self::GetHeaders(locator_hashes) => {
                 locator_hashes.encode(buffer)?;
-                MessageHeader::new(GETHEADERS_COMMAND, &buffer)
+                MessageHeader::new(GETHEADERS_COMMAND, buffer)
             }
             Self::Headers(headers) => {
                 headers.encode(buffer)?;
-                MessageHeader::new(HEADERS_COMMAND, &buffer)
+                MessageHeader::new(HEADERS_COMMAND, buffer)
             }
             Self::GetBlocks(locator_hashes) => {
                 locator_hashes.encode(buffer)?;
-                MessageHeader::new(GETBLOCKS_COMMAND, &buffer)
+                MessageHeader::new(GETBLOCKS_COMMAND, buffer)
             }
             Self::Block(block) => {
                 block.encode(buffer)?;
-                MessageHeader::new(BLOCK_COMMAND, &buffer)
+                MessageHeader::new(BLOCK_COMMAND, buffer)
             }
             Self::GetData(inv) => {
                 inv.encode(buffer)?;
-                MessageHeader::new(GETDATA_COMMAND, &buffer)
+                MessageHeader::new(GETDATA_COMMAND, buffer)
             }
             Self::Inv(inv) => {
                 inv.encode(buffer)?;
-                MessageHeader::new(INV_COMMAND, &buffer)
+                MessageHeader::new(INV_COMMAND, buffer)
             }
             Self::NotFound(inv) => {
                 inv.encode(buffer)?;
-                MessageHeader::new(NOTFOUND_COMMAND, &buffer)
+                MessageHeader::new(NOTFOUND_COMMAND, buffer)
             }
-            Self::MemPool => MessageHeader::new(MEMPOOL_COMMAND, &buffer),
+            Self::MemPool => MessageHeader::new(MEMPOOL_COMMAND, buffer),
             Self::Tx(tx) => {
                 tx.encode(buffer)?;
-                MessageHeader::new(TX_COMMAND, &buffer)
+                MessageHeader::new(TX_COMMAND, buffer)
             }
             Self::Reject(reject) => {
                 reject.encode(buffer)?;
-                MessageHeader::new(REJECT_COMMAND, &buffer)
+                MessageHeader::new(REJECT_COMMAND, buffer)
             }
             Self::FilterLoad(filter_load) => {
                 filter_load.encode(buffer)?;
-                MessageHeader::new(FILTERLOAD_COMMAND, &buffer)
+                MessageHeader::new(FILTERLOAD_COMMAND, buffer)
             }
             Self::FilterAdd(filter) => {
                 filter.encode(buffer)?;
-                MessageHeader::new(FILTERADD_COMMAND, &buffer)
+                MessageHeader::new(FILTERADD_COMMAND, buffer)
             }
-            Self::FilterClear => MessageHeader::new(FILTERCLEAR_COMMAND, &buffer),
+            Self::FilterClear => MessageHeader::new(FILTERCLEAR_COMMAND, buffer),
         };
 
         Ok(header)

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -75,7 +75,7 @@ async fn handshake_initiator_side() {
 
     // Check the connection has been established (this is only set post-handshake). We can't check
     // for the addr as nodes use ephemeral addresses when initiating connections.
-    wait_until!(1, synthetic_node.num_connected() == 1);
+    wait_until!(5, synthetic_node.num_connected() == 1);
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -369,12 +369,8 @@ async fn reject_version_reusing_nonce() {
     //
     // The node rejects connections reusing its nonce (usually indicative of self-connection).
     //
-    // 1. Wait for node to send version
-    // 2. Send back version with same nonce
-    // 3. Connection should be terminated
-    //
-    // zebra: doesn't disconnect.
-    // zcashd:
+    // zebra: closes the write half of the stream, doesn't close the socket.
+    // zcashd: closes the write half of the stream, doesn't close the socket.
 
     // Create a synthetic node, no handshake, no message filters.
     let mut synthetic_node = SyntheticNode::new(SyntheticNodeConfig::default())

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -268,7 +268,6 @@ async fn ignore_non_verack_replies_to_verack() {
     let test_messages = vec![
         Message::GetAddr,
         Message::MemPool,
-        Message::Verack,
         Message::Ping(Nonce::default()),
         Message::Pong(Nonce::default()),
         Message::GetAddr,

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -23,6 +23,9 @@ use crate::{
 use assert_matches::assert_matches;
 use tokio::net::{TcpListener, TcpStream};
 
+// Default timeout for connection reads in seconds.
+const TIMEOUT: u64 = 2;
+
 #[tokio::test]
 async fn handshake_responder_side() {
     // ZG-CONFORMANCE-001
@@ -133,10 +136,6 @@ async fn ignore_non_version_before_handshake() {
             .unwrap();
 
         // Expect the node to ignore the previous message, verify by completing the handshake.
-        // Read Version.
-        let version = synthetic_node.recv_message_timeout(2).await.unwrap();
-        assert_matches!(version, Message::Version(..));
-
         // Send Version.
         synthetic_node
             .send_direct_message(
@@ -146,8 +145,12 @@ async fn ignore_non_version_before_handshake() {
             .await
             .unwrap();
 
+        // Read Version.
+        let version = synthetic_node.recv_message_timeout(TIMEOUT).await.unwrap();
+        assert_matches!(version, Message::Version(..));
+
         // Read Verack.
-        let verack = synthetic_node.recv_message_timeout(2).await.unwrap();
+        let verack = synthetic_node.recv_message_timeout(TIMEOUT).await.unwrap();
         assert_matches!(verack, Message::Verack);
 
         // Gracefully shut down the synthetic node.

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -24,7 +24,7 @@ use assert_matches::assert_matches;
 use tokio::net::{TcpListener, TcpStream};
 
 // Default timeout for connection reads in seconds.
-const TIMEOUT: u64 = 5;
+const TIMEOUT: u64 = 10;
 
 #[tokio::test]
 async fn handshake_responder_side() {
@@ -174,8 +174,8 @@ async fn ignore_non_version_replies_to_version() {
     //
     // Due to how we instrument the test node, we need to have the list of peers ready when we start the node.
     //
-    // zebra:
-    // zcashd:
+    // zebra: doesn't respond to verack and disconnects.
+    // zcashd: ignores the message and completes the handshake.
 
     let genesis_block = Block::testnet_genesis();
     let block_hash = genesis_block.double_sha256().unwrap();

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -48,6 +48,8 @@ async fn handshake_responder_side() {
     // This is only set post-handshake (if enabled).
     assert!(synthetic_node.is_connected(node.addr()));
 
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down();
     node.stop().await;
 }
 
@@ -75,6 +77,8 @@ async fn handshake_initiator_side() {
     // for the addr as nodes use ephemeral addresses when initiating connections.
     wait_until!(1, synthetic_node.num_connected() == 1);
 
+    // Gracefully shut down the nodes.
+    synthetic_node.shut_down();
     node.stop().await;
 }
 
@@ -150,6 +154,7 @@ async fn ignore_non_version_before_handshake() {
         synthetic_node.shut_down();
     }
 
+    // Gracefully shut down the node.
     node.stop().await;
 }
 

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -406,7 +406,7 @@ async fn reject_obsolete_versions() {
     // zebra: doesn't send reject, sends version before closing the write half of the stream,
     // doesn't close the socket.
     //
-    // zcashd:
+    // zcashd: sends reject before closing the write half of the stream, doesn't close the socket.
 
     let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
 

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -1,7 +1,7 @@
 use crate::{
     helpers::{
         autorespond_and_expect_disconnect, initiate_handshake, respond_to_handshake,
-        synthetic_peers::SyntheticNode,
+        synthetic_peers::{SyntheticNode, SyntheticNodeConfig},
     },
     protocol::{
         message::{
@@ -30,10 +30,13 @@ use tokio::{
 
 #[tokio::test]
 async fn ping_pong() {
-    // Create a pea2pea backed synthetic node and enable handshaking.
-    let filter = MessageFilter::with_all_auto_reply();
-    let mut synthetic_node =
-        SyntheticNode::new(pea2pea::Node::new(None).await.unwrap(), true, filter);
+    // Create a synthetic node and enable handshaking.
+    let mut synthetic_node = SyntheticNode::new(SyntheticNodeConfig {
+        enable_handshaking: true,
+        ..Default::default()
+    })
+    .await
+    .unwrap();
 
     // Create a node and set the listener as an initial peer.
     let mut node: Node = Default::default();


### PR DESCRIPTION
Note: both `zcashd` and `zebra` only close their write half of the connection and don't fully drop the socket when a disconnect is expected (pea2pea doesn't detect the stream close at time of writing: https://github.com/ljedrz/pea2pea/issues/5). The previous version of the tests detected a disconnect because we were using `read_exact` instead of `read` as does pea2pea. I've also updated the spec and pass/fail table to reflect the changes.

Interestingly both `zcashd` and `zebra` also have failing ping/pong tests (if we actually check the `nonce`). 

The synthetic node API is also unstable at this point, though inching closer to something I'm happy with. 