### PR TITLE
ref: conformance tests with synthetic nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ features = [ "derive" ]
 version = "1"
 features = [ "full" ]
 
+[dependencies.tracing]
+version = "0.1"
+default-features = false
+
 [dependencies.tracing-subscriber]
 version = "0.2.18"
 features = [ "env-filter", "fmt" ]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Short overview of test cases and their current status. In case of failure, the b
 | [009](SPEC.md#ZG-CONFORMANCE-009) |   ✓    |   ✓   |
 | [010](SPEC.md#ZG-CONFORMANCE-010) |   ✖    |   ✖   | ⚠ todo: mempool seeding
 | [011](SPEC.md#ZG-CONFORMANCE-011) |   ✖    |   ✖   |
-| [012](SPEC.md#ZG-CONFORMANCE-012) |   ✖    |   ✓   | ⚠ zcashd peering issues, zebra passes with caveat
+| [012](SPEC.md#ZG-CONFORMANCE-012) |   ✖    |   ✖   | ⚠ zcashd peering issues, zebra passes under certain conditions
 | [013](SPEC.md#ZG-CONFORMANCE-013) |   ✖    |   ✖   | ⚠ zcashd peering issues
 | [014](SPEC.md#ZG-CONFORMANCE-014) |   -    |   -   | ⚠ Not yet implemented (blocked by mempool seeding)
 | [015](SPEC.md#ZG-CONFORMANCE-015) |   ✓    |   -   | ⚠ todo: zebra block seeding

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Short overview of test cases and their current status. In case of failure, the b
 | [014](SPEC.md#ZG-CONFORMANCE-014) |   -    |   -   | ⚠ Not yet implemented (blocked by mempool seeding)
 | [015](SPEC.md#ZG-CONFORMANCE-015) |   ✓    |   -   | ⚠ todo: zebra block seeding
 | [016](SPEC.md#ZG-CONFORMANCE-016) |   ✖    |   -   | ⚠ todo: zebra block seeding
-| [017](SPEC.md#ZG-CONFORMANCE-017) |   ✓    |   ✖   | ⚠ partially implemented (requires mempool seeding, and zebra block seeding)
+| [017](SPEC.md#ZG-CONFORMANCE-017) |   ✖    |   ✖   | ⚠ partially implemented (requires mempool seeding, and zebra block seeding)
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Short overview of test cases and their current status. In case of failure, the b
 | [009](SPEC.md#ZG-CONFORMANCE-009) |   ✓    |   ✓   |
 | [010](SPEC.md#ZG-CONFORMANCE-010) |   ✖    |   ✖   | ⚠ todo: mempool seeding
 | [011](SPEC.md#ZG-CONFORMANCE-011) |   ✖    |   ✖   |
-| [012](SPEC.md#ZG-CONFORMANCE-012) |   ✖    |   ✖   | ⚠ zcashd peering issues
+| [012](SPEC.md#ZG-CONFORMANCE-012) |   ✖    |   ✓   | ⚠ zcashd peering issues, zebra passes with caveat
 | [013](SPEC.md#ZG-CONFORMANCE-013) |   ✖    |   ✖   | ⚠ zcashd peering issues
 | [014](SPEC.md#ZG-CONFORMANCE-014) |   -    |   -   | ⚠ Not yet implemented (blocked by mempool seeding)
 | [015](SPEC.md#ZG-CONFORMANCE-015) |   ✓    |   -   | ⚠ todo: zebra block seeding

--- a/SPEC.md
+++ b/SPEC.md
@@ -152,8 +152,7 @@ The fuzz tests aim to buttress the message conformance tests with extra verifica
 
     1. Establish handshaken node and peer.
     2. Send an unsolicited message to be ignored.
-    3. Assert the node ignored the unsolicited message and didn’t drop the connection (not sure how yet, perhaps by sending a ping and verifying that works
-    as intended).
+    3. Assert the node ignored the unsolicited message and didn’t drop the connection.
 
     Messages to be tested: `Reject`, `NotFound`, `Pong`, `Tx`, `Block`, `Header`, `Addr`.
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -13,6 +13,9 @@ use tokio::{
 
 use std::{net::SocketAddr, time::Duration};
 
+// Default timeout for connection reads in seconds.
+pub const TIMEOUT: u64 = 10;
+
 pub fn enable_tracing() {
     use tracing_subscriber::{fmt, EnvFilter};
 

--- a/src/protocol/message/filter.rs
+++ b/src/protocol/message/filter.rs
@@ -31,7 +31,7 @@ pub enum Filter {
 /// For a list of responses see the documentation on [MessageFilter::read_from_stream].
 ///
 /// Can optionally log filter events to console, logging is disabled by default.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct MessageFilter {
     ping: Filter,
     getheaders: Filter,

--- a/src/protocol/message/mod.rs
+++ b/src/protocol/message/mod.rs
@@ -1,5 +1,7 @@
 pub mod constants;
 pub mod filter;
+
+#[doc(hidden)]
 pub mod io;
 
 use crate::protocol::{

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -169,7 +169,7 @@ impl Node {
             Action::None => {}
             Action::WaitForConnection => {
                 // The synthetic node will accept the connection and handshake by itself.
-                wait_until!(10, synthetic_node.num_connected() == 1);
+                wait_until!(TIMEOUT, synthetic_node.num_connected() == 1);
             }
             Action::SeedWithTestnetBlocks(_) if self.meta.kind == NodeKind::Zebra => {
                 unimplemented!("zebra doesn't support block seeding");
@@ -229,6 +229,7 @@ impl Node {
                     (_, msg) => panic!("Expected GetData but got: {:?}", msg),
                 }
 
+                // Check that the node has received and processed all previous messages.
                 synthetic_node.assert_ping_pong(source).await;
             }
         }

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -1,23 +1,17 @@
 use crate::{
-    helpers::{
-        respond_to_handshake,
-        synthetic_peers::{SyntheticNode, SyntheticNodeConfig},
-    },
+    helpers::synthetic_peers::{SyntheticNode, SyntheticNodeConfig},
     protocol::{
         message::filter::{Filter, MessageFilter},
         payload::{
             block::{Block, Headers},
-            Hash, Inv, Nonce,
+            Hash, Inv,
         },
     },
     setup::config::{NodeConfig, NodeKind, NodeMetaData, ZcashdConfigFile, ZebraConfigFile},
     wait_until,
 };
 
-use tokio::{
-    net::TcpListener,
-    process::{Child, Command},
-};
+use tokio::process::{Child, Command};
 
 use std::{fs, net::SocketAddr, process::Stdio};
 

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -26,7 +26,7 @@ async fn handshake_responder_side() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -107,7 +107,7 @@ async fn ignore_non_version_before_handshake() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -407,7 +407,7 @@ async fn reject_obsolete_versions() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -11,10 +11,7 @@ use crate::{
             Addr, Hash, Inv, Nonce, Version,
         },
     },
-    setup::{
-        config::new_local_addr,
-        node::{Action, Node},
-    },
+    setup::node::{Action, Node},
     wait_until,
 };
 

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -1,5 +1,8 @@
 use crate::{
-    helpers::synthetic_peers::{SyntheticNode, SyntheticNodeConfig},
+    helpers::{
+        synthetic_peers::{SyntheticNode, SyntheticNodeConfig},
+        TIMEOUT,
+    },
     protocol::{
         message::{filter::MessageFilter, Message},
         payload::{
@@ -16,9 +19,6 @@ use crate::{
 };
 
 use assert_matches::assert_matches;
-
-// Default timeout for connection reads in seconds.
-const TIMEOUT: u64 = 10;
 
 #[tokio::test]
 async fn handshake_responder_side() {

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -26,9 +26,7 @@ async fn handshake_responder_side() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     // Create a synthetic node and enable handshaking.
     let synthetic_node = SyntheticNode::new(SyntheticNodeConfig {
@@ -107,9 +105,7 @@ async fn ignore_non_version_before_handshake() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     // Configuration to be used by all synthetic nodes, no handshaking, no message filters.
     let config: SyntheticNodeConfig = Default::default();
@@ -407,9 +403,7 @@ async fn reject_obsolete_versions() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     // Configuration for all synthetic nodes, no handshake, no message filter.
     let config: SyntheticNodeConfig = Default::default();

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -28,39 +28,6 @@ use assert_matches::assert_matches;
 use std::net::SocketAddr;
 
 #[tokio::test]
-async fn ping_pong() {
-    // Create a synthetic node and enable handshaking.
-    let mut synthetic_node = SyntheticNode::new(SyntheticNodeConfig {
-        enable_handshaking: true,
-        ..Default::default()
-    })
-    .await
-    .unwrap();
-
-    // Spin up a node.
-    let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
-        .start()
-        .await;
-
-    // Connect to the node and handshake.
-    synthetic_node.connect(node.addr()).await.unwrap();
-
-    // Send ping.
-    let ping_nonce = Nonce::default();
-    synthetic_node
-        .send_direct_message(node.addr(), Message::Ping(ping_nonce))
-        .await
-        .unwrap();
-
-    // Recieve pong and verify the nonce matches.
-    let (_, pong) = synthetic_node.recv_message().await;
-    assert_matches!(pong, Message::Pong(pong_nonce) if pong_nonce == ping_nonce);
-
-    node.stop().await;
-}
-
-#[tokio::test]
 async fn reject_invalid_messages() {
     // ZG-CONFORMANCE-008
     //

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -66,9 +66,7 @@ async fn reject_invalid_messages() {
 
     // Spin up a node instance (so we have acces to its addr).
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     // Generate a mixed Inventory hash set.
     let genesis_block = Block::testnet_genesis();
@@ -142,9 +140,7 @@ async fn ignores_unsolicited_responses() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     // Create a synthetic node.
     let mut synthetic_node = SyntheticNode::new(SyntheticNodeConfig {
@@ -212,8 +208,8 @@ async fn basic_query_response_seeded() {
     // Spin up a node instance.
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
-    .start()
-    .await;
+        .start()
+        .await;
 
     // Create a synthetic node.
     let mut synthetic_node = SyntheticNode::new(SyntheticNodeConfig {
@@ -355,9 +351,7 @@ async fn basic_query_response_unseeded() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     // Create a synthetic node with message filtering.
     let mut synthetic_node = SyntheticNode::new(SyntheticNodeConfig {
@@ -421,9 +415,7 @@ async fn disconnects_for_trivial_issues() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     // Configuration letting through ping messages for the first case.
     let config = SyntheticNodeConfig {
@@ -524,9 +516,7 @@ async fn eagerly_crawls_network_for_peers() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     // Create 5 synthetic nodes.
     const N: usize = 5;
@@ -576,6 +566,7 @@ async fn eagerly_crawls_network_for_peers() {
     // Expect the synthetic nodes to get a connection request from the node.
     for node in synthetic_nodes {
         wait_until!(TIMEOUT, node.num_connected() == 1);
+
         node.shut_down();
     }
 
@@ -712,8 +703,8 @@ async fn get_blocks() {
     // Create a node with knowledge of the initial three testnet blocks
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
-    .start()
-    .await;
+        .start()
+        .await;
 
     let blocks = Block::initial_testnet_blocks();
 
@@ -849,8 +840,8 @@ async fn correctly_lists_blocks() {
     // Create a node with knowledge of the initial three testnet blocks
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
-    .start()
-    .await;
+        .start()
+        .await;
 
     // block headers and hashes
     let expected = Block::initial_testnet_blocks()
@@ -973,8 +964,8 @@ async fn get_data_blocks() {
     // Create a node with knowledge of the initial three testnet blocks
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
-    .start()
-    .await;
+        .start()
+        .await;
 
     // block headers and hashes
     let blocks = vec![

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -536,8 +536,7 @@ async fn eagerly_crawls_network_for_peers() {
     // Collect their addrs.
     let addrs = synthetic_nodes
         .iter()
-        .map(|node| node.listening_addr())
-        .map(|addr| NetworkAddr::new(addr))
+        .map(|node| NetworkAddr::new(node.listening_addr()))
         .collect::<Vec<_>>();
 
     // Adjust the config so it lets through GetAddr message and start a "main" synthetic node which
@@ -903,7 +902,7 @@ async fn correctly_lists_blocks() {
             .unwrap();
 
         // We use start+1 because Headers should list the blocks starting *after* the
-        // final location in GetHeaders, and up (and including) the stop-hash.
+        // final location in GetHeaders, and up to (and including) the stop-hash.
         let (_, headers) = synthetic_node.recv_message_timeout(TIMEOUT).await.unwrap();
         let headers = assert_matches!(headers, Message::Headers(headers) => headers);
         assert_eq!(

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -567,8 +567,9 @@ async fn eagerly_crawls_network_for_peers() {
         .await;
 
     // Create 5 synthetic nodes.
-    let mut synthetic_nodes = Vec::with_capacity(4);
-    for _ in 0..synthetic_nodes.len() {
+    const N: usize = 5;
+    let mut synthetic_nodes = Vec::with_capacity(N);
+    for _ in 0..N {
         let synthetic_node = SyntheticNode::new(SyntheticNodeConfig {
             enable_handshaking: true,
             message_filter: MessageFilter::with_all_auto_reply(),

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -66,7 +66,7 @@ async fn reject_invalid_messages() {
 
     // Spin up a node instance (so we have acces to its addr).
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -142,7 +142,7 @@ async fn ignores_unsolicited_responses() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -211,10 +211,7 @@ async fn basic_query_response_seeded() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::SeedWithTestnetBlocks {
-        socket_addr: new_local_addr(),
-        block_count: 3,
-    })
+    node.initial_action(Action::SeedWithTestnetBlocks(3))
     .start()
     .await;
 
@@ -358,7 +355,7 @@ async fn basic_query_response_unseeded() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -424,7 +421,7 @@ async fn disconnects_for_trivial_issues() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -527,7 +524,7 @@ async fn eagerly_crawls_network_for_peers() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -640,7 +637,7 @@ async fn correctly_lists_peers() {
 
     // Start node with the synthetic nodes as initial peers.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .initial_peers(expected_addrs.clone())
         .start()
         .await;
@@ -714,10 +711,7 @@ async fn get_blocks() {
 
     // Create a node with knowledge of the initial three testnet blocks
     let mut node: Node = Default::default();
-    node.initial_action(Action::SeedWithTestnetBlocks {
-        socket_addr: new_local_addr(),
-        block_count: 3,
-    })
+    node.initial_action(Action::SeedWithTestnetBlocks(3))
     .start()
     .await;
 
@@ -854,10 +848,7 @@ async fn correctly_lists_blocks() {
 
     // Create a node with knowledge of the initial three testnet blocks
     let mut node: Node = Default::default();
-    node.initial_action(Action::SeedWithTestnetBlocks {
-        socket_addr: new_local_addr(),
-        block_count: 3,
-    })
+    node.initial_action(Action::SeedWithTestnetBlocks(3))
     .start()
     .await;
 
@@ -981,10 +972,7 @@ async fn get_data_blocks() {
 
     // Create a node with knowledge of the initial three testnet blocks
     let mut node: Node = Default::default();
-    node.initial_action(Action::SeedWithTestnetBlocks {
-        socket_addr: new_local_addr(),
-        block_count: 3,
-    })
+    node.initial_action(Action::SeedWithTestnetBlocks(3))
     .start()
     .await;
 

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -1,6 +1,5 @@
 use crate::{
     helpers::{
-        initiate_handshake,
         synthetic_peers::{SyntheticNode, SyntheticNodeConfig},
         TIMEOUT,
     },
@@ -25,9 +24,8 @@ use crate::{
 };
 
 use assert_matches::assert_matches;
-use tokio::time::timeout;
 
-use std::{net::SocketAddr, time::Duration};
+use std::net::SocketAddr;
 
 #[tokio::test]
 async fn ping_pong() {
@@ -1102,31 +1100,5 @@ async fn get_data_blocks() {
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();
-    node.stop().await;
-}
-
-#[allow(dead_code)]
-async fn unsolicitation_listener() {
-    let mut node: Node = Default::default();
-    node.start().await;
-
-    let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();
-
-    let auto_responder = MessageFilter::with_all_auto_reply().enable_logging();
-
-    for _ in 0usize..10 {
-        let result = timeout(
-            Duration::from_secs(5),
-            auto_responder.read_from_stream(&mut peer_stream),
-        )
-        .await;
-
-        match result {
-            Err(elapsed) => println!("Timeout after {}", elapsed),
-            Ok(Ok(message)) => println!("Received unfiltered message: {:?}", message),
-            Ok(Err(err)) => println!("Error receiving message: {:?}", err),
-        }
-    }
-
     node.stop().await;
 }

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -183,7 +183,7 @@ async fn ignores_unsolicited_responses() {
     // Create a synthetic node.
     let mut synthetic_node = SyntheticNode::new(SyntheticNodeConfig {
         enable_handshaking: true,
-        message_filter: MessageFilter::with_all_auto_reply(),
+        message_filter: MessageFilter::with_all_enabled(),
         ..Default::default()
     })
     .await
@@ -202,6 +202,7 @@ async fn ignores_unsolicited_responses() {
     ];
 
     for message in test_messages {
+        // Send the unsolicited message.
         synthetic_node
             .send_direct_message(node.addr(), message)
             .await
@@ -211,6 +212,7 @@ async fn ignores_unsolicited_responses() {
         synthetic_node.assert_ping_pong(node.addr()).await;
     }
 
+    // Gracefully shut down the nodes.
     synthetic_node.shut_down();
     node.stop().await;
 }

--- a/src/tests/performance/blocks.rs
+++ b/src/tests/performance/blocks.rs
@@ -9,10 +9,7 @@ use crate::{
         message::{filter::MessageFilter, Message},
         payload::{block::Block, Inv},
     },
-    setup::{
-        config::new_local_addr,
-        node::{Action, Node},
-    },
+    setup::node::{Action, Node},
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]

--- a/src/tests/performance/blocks.rs
+++ b/src/tests/performance/blocks.rs
@@ -112,9 +112,9 @@ async fn getdata_blocks_latency() {
     // with max peers set so that our peers should never be rejected.
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
-    .max_peers(peer_counts.iter().max().unwrap() * 2 + 10)
-    .start()
-    .await;
+        .max_peers(peer_counts.iter().max().unwrap() * 2 + 10)
+        .start()
+        .await;
     let node_addr = node.addr();
 
     for peers in peer_counts {

--- a/src/tests/performance/blocks.rs
+++ b/src/tests/performance/blocks.rs
@@ -111,10 +111,7 @@ async fn getdata_blocks_latency() {
     // Start node seeded with initial testnet blocks,
     // with max peers set so that our peers should never be rejected.
     let mut node: Node = Default::default();
-    node.initial_action(Action::SeedWithTestnetBlocks {
-        socket_addr: new_local_addr(),
-        block_count: 3,
-    })
+    node.initial_action(Action::SeedWithTestnetBlocks(3))
     .max_peers(peer_counts.iter().max().unwrap() * 2 + 10)
     .start()
     .await;

--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -1,10 +1,7 @@
 use crate::{
     helpers::{initiate_handshake, is_rejection_error, is_termination_error},
     protocol::message::{filter::MessageFilter, Message},
-    setup::{
-        config::new_local_addr,
-        node::{Action, Node},
-    },
+    setup::node::{Action, Node},
 };
 
 #[derive(Debug)]

--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -98,7 +98,7 @@ async fn incoming_active_connections() {
 
     // start node
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .max_peers(MAX_PEERS)
         .start()
         .await;

--- a/src/tests/performance/ping.rs
+++ b/src/tests/performance/ping.rs
@@ -116,7 +116,7 @@ async fn ping_pong_latency() {
     // start node, with max peers set so that our peers should
     // never be rejected.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .max_peers(peer_counts.iter().max().unwrap() * 2 + 10)
         .start()
         .await;

--- a/src/tests/performance/ping.rs
+++ b/src/tests/performance/ping.rs
@@ -9,10 +9,7 @@ use crate::{
         message::{filter::MessageFilter, Message},
         payload::Nonce,
     },
-    setup::{
-        config::new_local_addr,
-        node::{Action, Node},
-    },
+    setup::node::{Action, Node},
 };
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]

--- a/src/tests/resistance/fuzzing_corrupted_messages.rs
+++ b/src/tests/resistance/fuzzing_corrupted_messages.rs
@@ -38,9 +38,7 @@ async fn corrupted_version_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -71,9 +69,7 @@ async fn corrupted_version_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
@@ -244,9 +240,7 @@ async fn corrupted_version_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();
@@ -278,9 +272,7 @@ async fn corrupted_messages_pre_handshake() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -305,9 +297,7 @@ async fn corrupted_messages_during_handshake_responder_side() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
@@ -465,9 +455,7 @@ async fn corrupted_messages_post_handshake() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();

--- a/src/tests/resistance/fuzzing_corrupted_messages.rs
+++ b/src/tests/resistance/fuzzing_corrupted_messages.rs
@@ -38,7 +38,7 @@ async fn corrupted_version_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -71,7 +71,7 @@ async fn corrupted_version_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -244,7 +244,7 @@ async fn corrupted_version_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -278,7 +278,7 @@ async fn corrupted_messages_pre_handshake() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -305,7 +305,7 @@ async fn corrupted_messages_during_handshake_responder_side() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -465,7 +465,7 @@ async fn corrupted_messages_post_handshake() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 

--- a/src/tests/resistance/fuzzing_flood.rs
+++ b/src/tests/resistance/fuzzing_flood.rs
@@ -212,10 +212,7 @@ async fn rising_fuzz() {
     // need for the test. Note that zcashd node appears to reserver 8
     // slots (hence the +10).
     let mut node: Node = Default::default();
-    node.initial_action(Action::SeedWithTestnetBlocks {
-        socket_addr: new_local_addr(),
-        block_count: 3,
-    })
+    node.initial_action(Action::SeedWithTestnetBlocks(3))
     .max_peers(peer_counts.iter().max().unwrap() * 2 + 10)
     .start()
     .await;

--- a/src/tests/resistance/fuzzing_flood.rs
+++ b/src/tests/resistance/fuzzing_flood.rs
@@ -213,9 +213,9 @@ async fn rising_fuzz() {
     // slots (hence the +10).
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
-    .max_peers(peer_counts.iter().max().unwrap() * 2 + 10)
-    .start()
-    .await;
+        .max_peers(peer_counts.iter().max().unwrap() * 2 + 10)
+        .start()
+        .await;
 
     let node_addr = node.addr();
 

--- a/src/tests/resistance/fuzzing_flood.rs
+++ b/src/tests/resistance/fuzzing_flood.rs
@@ -15,10 +15,7 @@ use crate::{
             Hash, Inv, Nonce,
         },
     },
-    setup::{
-        config::new_local_addr,
-        node::{Action, Node},
-    },
+    setup::node::{Action, Node},
     tests::resistance::{
         default_fuzz_messages,
         fuzzing_corrupted_messages::slightly_corrupted_messages,

--- a/src/tests/resistance/fuzzing_incorrect_checksum.rs
+++ b/src/tests/resistance/fuzzing_incorrect_checksum.rs
@@ -29,9 +29,7 @@ async fn version_with_incorrect_checksum_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -63,9 +61,7 @@ async fn incorrect_checksum_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     let test_messages = default_fuzz_messages();
 
@@ -98,9 +94,7 @@ async fn version_with_incorrect_checksum_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
@@ -131,9 +125,7 @@ async fn version_with_incorrect_checksum_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();
@@ -165,9 +157,7 @@ async fn incorrect_checksum_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     let test_messages = default_fuzz_messages();
 
@@ -332,9 +322,7 @@ async fn incorrect_checksum_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     let test_messages = default_fuzz_messages();
 

--- a/src/tests/resistance/fuzzing_incorrect_checksum.rs
+++ b/src/tests/resistance/fuzzing_incorrect_checksum.rs
@@ -29,7 +29,7 @@ async fn version_with_incorrect_checksum_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -63,7 +63,7 @@ async fn incorrect_checksum_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -98,7 +98,7 @@ async fn version_with_incorrect_checksum_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -131,7 +131,7 @@ async fn version_with_incorrect_checksum_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -165,7 +165,7 @@ async fn incorrect_checksum_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -332,7 +332,7 @@ async fn incorrect_checksum_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 

--- a/src/tests/resistance/fuzzing_incorrect_length.rs
+++ b/src/tests/resistance/fuzzing_incorrect_length.rs
@@ -32,9 +32,7 @@ async fn version_with_incorrect_length_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -66,9 +64,7 @@ async fn incorrect_length_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     let test_messages = default_fuzz_messages();
 
@@ -100,9 +96,7 @@ async fn version_with_incorrect_length_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
@@ -292,9 +286,7 @@ async fn version_with_incorrect_length_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for _ in 0..ITERATIONS {
         let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();
@@ -326,9 +318,7 @@ async fn incorrect_length_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     let test_messages = default_fuzz_messages();
 
@@ -497,9 +487,7 @@ async fn incorrect_length_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     let test_messages = default_fuzz_messages();
 

--- a/src/tests/resistance/fuzzing_incorrect_length.rs
+++ b/src/tests/resistance/fuzzing_incorrect_length.rs
@@ -32,7 +32,7 @@ async fn version_with_incorrect_length_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -66,7 +66,7 @@ async fn incorrect_length_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -100,7 +100,7 @@ async fn version_with_incorrect_length_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -292,7 +292,7 @@ async fn version_with_incorrect_length_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -326,7 +326,7 @@ async fn incorrect_length_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -497,7 +497,7 @@ async fn incorrect_length_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 

--- a/src/tests/resistance/fuzzing_random_bytes.rs
+++ b/src/tests/resistance/fuzzing_random_bytes.rs
@@ -27,9 +27,7 @@ async fn random_bytes_pre_handshake() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -52,9 +50,7 @@ async fn random_bytes_during_handshake_responder_side() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
@@ -205,9 +201,7 @@ async fn random_bytes_post_handshake() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();
@@ -234,9 +228,7 @@ async fn metadata_compliant_random_bytes_pre_handshake() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for (header, payload) in payloads {
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -262,9 +254,7 @@ async fn metadata_compliant_random_bytes_during_handshake_responder_side() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for (header, payload) in payloads {
         let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
@@ -428,9 +418,7 @@ async fn metadata_compliant_random_bytes_post_handshake() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for (header, payload) in payloads {
         let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();

--- a/src/tests/resistance/fuzzing_random_bytes.rs
+++ b/src/tests/resistance/fuzzing_random_bytes.rs
@@ -27,7 +27,7 @@ async fn random_bytes_pre_handshake() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -52,7 +52,7 @@ async fn random_bytes_during_handshake_responder_side() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -205,7 +205,7 @@ async fn random_bytes_post_handshake() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -234,7 +234,7 @@ async fn metadata_compliant_random_bytes_pre_handshake() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -262,7 +262,7 @@ async fn metadata_compliant_random_bytes_during_handshake_responder_side() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -428,7 +428,7 @@ async fn metadata_compliant_random_bytes_post_handshake() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 

--- a/src/tests/resistance/fuzzing_zeroes.rs
+++ b/src/tests/resistance/fuzzing_zeroes.rs
@@ -30,7 +30,7 @@ async fn zeroes_pre_handshake() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -55,7 +55,7 @@ async fn zeroes_during_handshake_responder_side() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 
@@ -208,7 +208,7 @@ async fn zeroes_post_handshake() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection(new_local_addr()))
+    node.initial_action(Action::WaitForConnection)
         .start()
         .await;
 

--- a/src/tests/resistance/fuzzing_zeroes.rs
+++ b/src/tests/resistance/fuzzing_zeroes.rs
@@ -30,9 +30,7 @@ async fn zeroes_pre_handshake() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = TcpStream::connect(node.addr()).await.unwrap();
@@ -55,9 +53,7 @@ async fn zeroes_during_handshake_responder_side() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = initiate_version_exchange(node.addr()).await.unwrap();
@@ -208,9 +204,7 @@ async fn zeroes_post_handshake() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection)
-        .start()
-        .await;
+    node.initial_action(Action::WaitForConnection).start().await;
 
     for payload in payloads {
         let mut peer_stream = initiate_handshake(node.addr()).await.unwrap();


### PR DESCRIPTION
Refactors the conformance tests with the pea2pea backed peers. 

Also includes:
- `tracing` additions to `SyntheticNode::process_message`
- refactored the initial node actions to use a synthetic peer
- removed some dead code