### PR TITLE
Improve setup code error handling

### DIFF
--- a/src/protocol/message/mod.rs
+++ b/src/protocol/message/mod.rs
@@ -15,7 +15,7 @@ use crate::protocol::{
 
 use sha2::{Digest, Sha256};
 
-use std::io::{Cursor, self, Write};
+use std::io::{self, Cursor, Write};
 
 /// The header of a network message.
 #[derive(Debug, Default, Clone)]

--- a/src/protocol/message/mod.rs
+++ b/src/protocol/message/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod constants;
 #[doc(hidden)]
-pub mod io;
+pub mod stream_io;
 
 use crate::protocol::{
     message::constants::*,
@@ -15,7 +15,7 @@ use crate::protocol::{
 
 use sha2::{Digest, Sha256};
 
-use std::io::{Cursor, Result, Write};
+use std::io::{Cursor, self, Write};
 
 /// The header of a network message.
 #[derive(Debug, Default, Clone)]
@@ -31,7 +31,7 @@ pub struct MessageHeader {
 }
 
 impl Codec for MessageHeader {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<()> {
+    fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
         buffer.write_all(&self.magic)?;
         buffer.write_all(&self.command)?;
         buffer.write_all(&self.body_length.to_le_bytes())?;
@@ -40,7 +40,7 @@ impl Codec for MessageHeader {
         Ok(())
     }
 
-    fn decode(bytes: &mut Cursor<&[u8]>) -> Result<Self> {
+    fn decode(bytes: &mut Cursor<&[u8]>) -> io::Result<Self> {
         Ok(MessageHeader {
             magic: read_n_bytes(bytes)?,
             command: read_n_bytes(bytes)?,
@@ -92,7 +92,7 @@ pub enum Message {
 impl Message {
     // FIXME: implement Codec?
     /// Encodes a message into the supplied buffer and returns its header.
-    pub fn encode(&self, buffer: &mut Vec<u8>) -> Result<MessageHeader> {
+    pub fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<MessageHeader> {
         let header = match self {
             Self::Version(version) => {
                 version.encode(buffer)?;
@@ -164,7 +164,7 @@ impl Message {
     }
 
     /// Decodes the bytes into a message.
-    pub fn decode(command: [u8; 12], bytes: &mut Cursor<&[u8]>) -> Result<Self> {
+    pub fn decode(command: [u8; 12], bytes: &mut Cursor<&[u8]>) -> io::Result<Self> {
         let message = match command {
             VERSION_COMMAND => Self::Version(Version::decode(bytes)?),
             VERACK_COMMAND => Self::Verack,

--- a/src/protocol/message/stream_io.rs
+++ b/src/protocol/message/stream_io.rs
@@ -7,13 +7,13 @@ use crate::protocol::{
     },
 };
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt, Result};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, self};
 
 use std::io::Cursor;
 
 impl MessageHeader {
     /// Writes the message header to the stream.
-    pub async fn write_to_stream<T: AsyncWriteExt + Unpin>(&self, stream: &mut T) -> Result<()> {
+    pub async fn write_to_stream<T: AsyncWriteExt + Unpin>(&self, stream: &mut T) -> io::Result<()> {
         let mut buffer = Vec::with_capacity(24);
         self.encode(&mut buffer)?;
 
@@ -23,7 +23,7 @@ impl MessageHeader {
     }
 
     /// Reads a message header from the stream.
-    pub async fn read_from_stream<T: AsyncReadExt + Unpin>(stream: &mut T) -> Result<Self> {
+    pub async fn read_from_stream<T: AsyncReadExt + Unpin>(stream: &mut T) -> io::Result<Self> {
         let mut header: MessageHeader = Default::default();
 
         stream.read_exact(&mut header.magic).await?;
@@ -37,7 +37,7 @@ impl MessageHeader {
 
 impl Message {
     /// Writes the message to the stream.
-    pub async fn write_to_stream<T: AsyncWriteExt + Unpin>(&self, stream: &mut T) -> Result<()> {
+    pub async fn write_to_stream<T: AsyncWriteExt + Unpin>(&self, stream: &mut T) -> io::Result<()> {
         // Buffer for the message payload.
         let mut buffer = vec![];
         let header = self.encode(&mut buffer)?;
@@ -49,7 +49,7 @@ impl Message {
     }
 
     /// Reads a message from the stream.
-    pub async fn read_from_stream<T: AsyncReadExt + Unpin>(stream: &mut T) -> Result<Self> {
+    pub async fn read_from_stream<T: AsyncReadExt + Unpin>(stream: &mut T) -> io::Result<Self> {
         let header = MessageHeader::read_from_stream(stream).await?;
 
         let mut buffer = vec![0u8; header.body_length as usize];

--- a/src/protocol/message/stream_io.rs
+++ b/src/protocol/message/stream_io.rs
@@ -7,13 +7,16 @@ use crate::protocol::{
     },
 };
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt, self};
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 
 use std::io::Cursor;
 
 impl MessageHeader {
     /// Writes the message header to the stream.
-    pub async fn write_to_stream<T: AsyncWriteExt + Unpin>(&self, stream: &mut T) -> io::Result<()> {
+    pub async fn write_to_stream<T: AsyncWriteExt + Unpin>(
+        &self,
+        stream: &mut T,
+    ) -> io::Result<()> {
         let mut buffer = Vec::with_capacity(24);
         self.encode(&mut buffer)?;
 
@@ -37,7 +40,10 @@ impl MessageHeader {
 
 impl Message {
     /// Writes the message to the stream.
-    pub async fn write_to_stream<T: AsyncWriteExt + Unpin>(&self, stream: &mut T) -> io::Result<()> {
+    pub async fn write_to_stream<T: AsyncWriteExt + Unpin>(
+        &self,
+        stream: &mut T,
+    ) -> io::Result<()> {
         // Buffer for the message payload.
         let mut buffer = vec![];
         let header = self.encode(&mut buffer)?;

--- a/src/protocol/payload/codec.rs
+++ b/src/protocol/payload/codec.rs
@@ -2,19 +2,21 @@
 
 use super::VarInt;
 
+use std::io;
+
 /// A trait for unifying encoding and decoding.
 pub trait Codec {
     /// Encodes the payload into the supplied buffer.
-    fn encode(&self, buffer: &mut Vec<u8>) -> std::io::Result<()>;
+    fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()>;
 
     /// Decodes the bytes and returns the payload.
-    fn decode(bytes: &mut std::io::Cursor<&[u8]>) -> std::io::Result<Self>
+    fn decode(bytes: &mut io::Cursor<&[u8]>) -> io::Result<Self>
     where
         Self: Sized;
 }
 
 impl<T: Codec> Codec for Vec<T> {
-    fn encode(&self, buffer: &mut Vec<u8>) -> std::io::Result<()> {
+    fn encode(&self, buffer: &mut Vec<u8>) -> io::Result<()> {
         VarInt(self.len()).encode(buffer)?;
         for element in self {
             element.encode(buffer)?;
@@ -23,13 +25,13 @@ impl<T: Codec> Codec for Vec<T> {
         Ok(())
     }
 
-    fn decode(bytes: &mut std::io::Cursor<&[u8]>) -> std::io::Result<Self>
+    fn decode(bytes: &mut io::Cursor<&[u8]>) -> io::Result<Self>
     where
         Self: Sized,
     {
         let length = *VarInt::decode(bytes)?;
         (0..length)
             .map(|_| T::decode(bytes))
-            .collect::<std::io::Result<Self>>()
+            .collect::<io::Result<Self>>()
     }
 }

--- a/src/protocol/payload/tx.rs
+++ b/src/protocol/payload/tx.rs
@@ -26,7 +26,7 @@ pub enum Tx {
 
 impl Tx {
     /// Calculates the double Sha256 hash for this transaction.
-    pub fn double_sha256(&self) -> std::io::Result<Hash> {
+    pub fn double_sha256(&self) -> io::Result<Hash> {
         let mut buffer = Vec::new();
 
         self.encode(&mut buffer)?;

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use tokio::process::{Child, Command};
 
-use std::{fs, io::Result, net::SocketAddr, process::Stdio, time::Duration};
+use std::{fs, io, net::SocketAddr, process::Stdio, time::Duration};
 
 // The names of the files the node configurations will be written to.
 const ZEBRA_CONFIG: &str = "zebra.toml";
@@ -114,7 +114,7 @@ impl Node {
     ///
     /// This function will write the appropriate configuration file and run the start command
     /// provided in `config.toml`.
-    pub async fn start(&mut self) -> Result<()> {
+    pub async fn start(&mut self) -> io::Result<()> {
         // cleanup any previous runs (node.stop won't always be reached e.g. test panics, or SIGINT)
         self.cleanup();
 
@@ -168,7 +168,7 @@ impl Node {
         Ok(())
     }
 
-    async fn perform_initial_action(&self, mut synthetic_node: SyntheticNode) -> Result<()> {
+    async fn perform_initial_action(&self, mut synthetic_node: SyntheticNode) -> io::Result<()> {
         const TIMEOUT: Duration = Duration::from_secs(10);
 
         match self.config.initial_action {
@@ -248,7 +248,7 @@ impl Node {
     ///
     /// The stop command will only be run if provided in the `config.toml` file as it may not be
     /// necessary to shutdown a node (killing the process is sometimes sufficient).
-    pub async fn stop(&mut self) -> Result<()> {
+    pub async fn stop(&mut self) -> io::Result<()> {
         if let Some(mut child) = self.process.take() {
             // Stop node process, and check for crash
             // (needs to happen before cleanup)
@@ -273,7 +273,7 @@ impl Node {
         Ok(())
     }
 
-    fn generate_config_file(&self) -> Result<()> {
+    fn generate_config_file(&self) -> io::Result<()> {
         let path = self.config_filepath();
         let content = match self.meta.kind {
             NodeKind::Zebra => ZebraConfigFile::generate(&self.config),

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -142,7 +142,7 @@ impl Node {
         };
 
         // Generate config files for Zebra or Zcashd node.
-        self.generate_config_file();
+        self.generate_config_file()?;
 
         let (stdout, stderr) = match self.config.log_to_stdout {
             true => (Stdio::inherit(), Stdio::inherit()),
@@ -273,14 +273,14 @@ impl Node {
         Ok(())
     }
 
-    fn generate_config_file(&self) {
+    fn generate_config_file(&self) -> Result<()> {
         let path = self.config_filepath();
         let content = match self.meta.kind {
             NodeKind::Zebra => ZebraConfigFile::generate(&self.config),
             NodeKind::Zcashd => ZcashdConfigFile::generate(&self.config),
         };
 
-        fs::write(path, content).unwrap();
+        fs::write(path, content)
     }
 
     fn config_filepath(&self) -> std::path::PathBuf {

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -42,7 +42,7 @@ async fn handshake_responder_side() {
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -69,7 +69,7 @@ async fn handshake_initiator_side() {
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -152,7 +152,7 @@ async fn ignore_non_version_before_handshake() {
     }
 
     // Gracefully shut down the node.
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -241,7 +241,7 @@ async fn ignore_non_version_replies_to_version() {
     }
 
     // Gracefully shut down the node.
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -345,7 +345,7 @@ async fn ignore_non_verack_replies_to_verack() {
     }
 
     // Gracefully shut down the node.
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -384,7 +384,7 @@ async fn reject_version_reusing_nonce() {
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -437,5 +437,5 @@ async fn reject_obsolete_versions() {
     }
 
     // Gracefully shut down the node.
-    node.stop().await;
+    node.stop().await.unwrap();
 }

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -22,7 +22,10 @@ async fn handshake_responder_side() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     // Create a synthetic node and enable handshaking.
     let synthetic_node = SyntheticNode::builder()
@@ -57,7 +60,8 @@ async fn handshake_initiator_side() {
     let mut node: Node = Default::default();
     node.initial_peers(vec![synthetic_node.listening_addr()])
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // Check the connection has been established (this is only set post-handshake). We can't check
     // for the addr as nodes use ephemeral addresses when initiating connections.
@@ -99,7 +103,10 @@ async fn ignore_non_version_before_handshake() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     // Configuration to be used by all synthetic nodes, no handshaking, no message filters.
     let node_builder = SyntheticNode::builder();
@@ -226,7 +233,7 @@ async fn ignore_non_version_replies_to_version() {
     }
 
     // Start the node instance with the initial peers.
-    node.initial_peers(addrs).start().await;
+    node.initial_peers(addrs).start().await.unwrap();
 
     // Run each future to completion.
     for handle in handles {
@@ -330,7 +337,7 @@ async fn ignore_non_verack_replies_to_verack() {
     }
 
     // Start the node instance with the initial peers.
-    node.initial_peers(addrs).start().await;
+    node.initial_peers(addrs).start().await.unwrap();
 
     // Run each future to completion.
     for handle in handles {
@@ -357,7 +364,8 @@ async fn reject_version_reusing_nonce() {
     let mut node: Node = Default::default();
     node.initial_peers(vec![synthetic_node.listening_addr()])
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // Receive a Version.
     let (source, version) = synthetic_node.recv_message_timeout(TIMEOUT).await.unwrap();
@@ -392,7 +400,10 @@ async fn reject_obsolete_versions() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     // Configuration for all synthetic nodes, no handshake, no message filter.
     let node_builder = SyntheticNode::builder();

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -61,7 +61,10 @@ async fn reject_invalid_messages() {
 
     // Spin up a node instance (so we have acces to its addr).
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     // Generate a mixed Inventory hash set.
     let genesis_block = Block::testnet_genesis();
@@ -133,7 +136,10 @@ async fn ignores_unsolicited_responses() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     // Create a synthetic node.
     let mut synthetic_node = SyntheticNode::builder()
@@ -204,7 +210,8 @@ async fn basic_query_response_seeded() {
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // Create a synthetic node.
     let mut synthetic_node = SyntheticNode::builder()
@@ -348,7 +355,10 @@ async fn basic_query_response_unseeded() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     // Create a synthetic node with message filtering.
     let mut synthetic_node = SyntheticNode::builder()
@@ -412,7 +422,10 @@ async fn disconnects_for_trivial_issues() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     // Configuration letting through ping messages for the first case.
     let node_builder = SyntheticNode::builder()
@@ -510,7 +523,10 @@ async fn eagerly_crawls_network_for_peers() {
 
     // Spin up a node instance.
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     // Create 5 synthetic nodes.
     const N: usize = 5;
@@ -604,7 +620,8 @@ async fn correctly_lists_peers() {
     node.initial_action(Action::WaitForConnection)
         .initial_peers(expected_addrs.clone())
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // Connect to node and request GetAddr. We perform multiple iterations to exercise the #2120
     // zebra bug.
@@ -671,7 +688,8 @@ async fn get_blocks() {
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .start()
-        .await;
+        .await
+        .unwrap();
 
     let blocks = Block::initial_testnet_blocks();
 
@@ -810,7 +828,8 @@ async fn correctly_lists_blocks() {
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // block headers and hashes
     let expected = Block::initial_testnet_blocks()
@@ -933,7 +952,8 @@ async fn get_data_blocks() {
     let mut node: Node = Default::default();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // block headers and hashes
     let blocks = vec![

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -116,7 +116,7 @@ async fn reject_invalid_messages() {
     }
 
     // Gracefully shut down the node.
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -177,7 +177,7 @@ async fn ignores_unsolicited_responses() {
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -323,7 +323,7 @@ async fn basic_query_response_seeded() {
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -387,7 +387,7 @@ async fn basic_query_response_unseeded() {
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -491,7 +491,7 @@ async fn disconnects_for_trivial_issues() {
     }
 
     // Gracefully shut down the node.
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -574,7 +574,7 @@ async fn eagerly_crawls_network_for_peers() {
     }
 
     // Gracefully shut down the node.
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -649,7 +649,7 @@ async fn correctly_lists_peers() {
         synthetic_node.shut_down();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -793,7 +793,7 @@ async fn get_blocks() {
     assert_eq!(inv, expected);
 
     synthetic_node.shut_down();
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -918,7 +918,7 @@ async fn correctly_lists_blocks() {
     let headers = assert_matches!(headers, Message::Headers(headers) => headers);
     assert_eq!(headers.headers, expected[2..], "test for forked Headers");
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -1033,5 +1033,5 @@ async fn get_data_blocks() {
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down();
-    node.stop().await;
+    node.stop().await.unwrap();
 }

--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -206,7 +206,7 @@ async fn load_bearing() {
         all_stats.push(stats);
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 
     // Display results table
     println!("{}", fmt_table(Table::new(&all_stats)));

--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -124,7 +124,8 @@ async fn load_bearing() {
     node.initial_action(Action::WaitForConnection)
         .max_peers(MAX_PEERS as usize)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     for synth_count in synth_counts {
         // clear and register metrics

--- a/src/tests/performance/getdata_blocks.rs
+++ b/src/tests/performance/getdata_blocks.rs
@@ -91,7 +91,8 @@ async fn throughput() {
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .max_peers(synth_counts.iter().max().unwrap() * 2 + 10)
         .start()
-        .await;
+        .await
+        .unwrap();
     let node_addr = node.addr();
 
     for synth_count in synth_counts {

--- a/src/tests/performance/getdata_blocks.rs
+++ b/src/tests/performance/getdata_blocks.rs
@@ -174,7 +174,7 @@ async fn throughput() {
         ));
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 
     // Display various percentiles
     println!("{}", table);

--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -127,7 +127,8 @@ async fn throughput() {
     node.initial_action(Action::WaitForConnection)
         .max_peers(synth_counts.iter().max().unwrap() * 2 + 10)
         .start()
-        .await;
+        .await
+        .unwrap();
     let node_addr = node.addr();
 
     for synth_count in synth_counts {

--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -167,7 +167,7 @@ async fn throughput() {
         ));
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 
     // Display results table
     println!("{}", table);

--- a/src/tests/resistance/fuzzing_corrupted_messages.rs
+++ b/src/tests/resistance/fuzzing_corrupted_messages.rs
@@ -60,7 +60,7 @@ async fn corrupted_version_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -106,7 +106,7 @@ async fn corrupted_version_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -174,7 +174,7 @@ async fn corrupted_version_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -243,7 +243,7 @@ async fn corrupted_version_inplace_of_verack_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -288,7 +288,7 @@ async fn corrupted_version_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -326,7 +326,7 @@ async fn corrupted_messages_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -367,7 +367,7 @@ async fn corrupted_messages_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -430,7 +430,7 @@ async fn corrupted_messages_inplace_of_version_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -496,7 +496,7 @@ async fn corrupted_messages_inplace_of_verack_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -537,7 +537,7 @@ async fn corrupted_messages_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 // Corrupt messages from the supplied set by replacing a random number of bytes with random bytes.

--- a/src/tests/resistance/fuzzing_corrupted_messages.rs
+++ b/src/tests/resistance/fuzzing_corrupted_messages.rs
@@ -33,7 +33,10 @@ async fn corrupted_version_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let synth_builder = SyntheticNode::builder().with_all_auto_reply();
 
@@ -73,7 +76,10 @@ async fn corrupted_version_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let synth_builder = SyntheticNode::builder()
         .with_version_exchange_handshake()
@@ -160,7 +166,8 @@ async fn corrupted_version_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -228,7 +235,8 @@ async fn corrupted_version_inplace_of_verack_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -250,7 +258,10 @@ async fn corrupted_version_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let synth_builder = SyntheticNode::builder()
         .with_all_auto_reply()
@@ -293,7 +304,10 @@ async fn corrupted_messages_pre_handshake() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let synth_builder = SyntheticNode::builder().with_all_auto_reply();
 
@@ -328,7 +342,10 @@ async fn corrupted_messages_during_handshake_responder_side() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let synth_builder = SyntheticNode::builder()
         .with_version_exchange_handshake()
@@ -405,7 +422,8 @@ async fn corrupted_messages_inplace_of_version_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -470,7 +488,8 @@ async fn corrupted_messages_inplace_of_verack_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -493,7 +512,10 @@ async fn corrupted_messages_post_handshake() {
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let synth_builder = SyntheticNode::builder()
         .with_all_auto_reply()

--- a/src/tests/resistance/fuzzing_incorrect_checksum.rs
+++ b/src/tests/resistance/fuzzing_incorrect_checksum.rs
@@ -59,7 +59,7 @@ async fn version_with_incorrect_checksum_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -108,7 +108,7 @@ async fn incorrect_checksum_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -158,7 +158,7 @@ async fn version_with_incorrect_checksum_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -206,7 +206,7 @@ async fn version_with_incorrect_checksum_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -257,7 +257,7 @@ async fn incorrect_checksum_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -319,7 +319,7 @@ async fn incorrect_checksum_inplace_of_version_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -384,7 +384,7 @@ async fn incorrect_checksum_inplace_of_verack_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -435,7 +435,7 @@ async fn incorrect_checksum_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 /// Picks `n` random messages from `message_pool`, encodes them and corrupts the checksum bytes.

--- a/src/tests/resistance/fuzzing_incorrect_checksum.rs
+++ b/src/tests/resistance/fuzzing_incorrect_checksum.rs
@@ -24,7 +24,10 @@ async fn version_with_incorrect_checksum_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for _ in 0..ITERATIONS {
         let mut synth_node = SyntheticNode::builder()
@@ -69,7 +72,10 @@ async fn incorrect_checksum_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let test_messages = default_fuzz_messages();
 
@@ -116,7 +122,10 @@ async fn version_with_incorrect_checksum_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for _ in 0..ITERATIONS {
         let mut synth_node = SyntheticNode::builder()
@@ -161,7 +170,10 @@ async fn version_with_incorrect_checksum_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for _ in 0..ITERATIONS {
         let mut synth_node = SyntheticNode::builder()
@@ -207,7 +219,10 @@ async fn incorrect_checksum_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let test_messages = default_fuzz_messages();
 
@@ -296,7 +311,8 @@ async fn incorrect_checksum_inplace_of_version_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -360,7 +376,8 @@ async fn incorrect_checksum_inplace_of_verack_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -379,7 +396,10 @@ async fn incorrect_checksum_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let test_messages = default_fuzz_messages();
 

--- a/src/tests/resistance/fuzzing_incorrect_length.rs
+++ b/src/tests/resistance/fuzzing_incorrect_length.rs
@@ -27,7 +27,10 @@ async fn version_with_incorrect_length_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for _ in 0..ITERATIONS {
         let mut synth_node = SyntheticNode::builder()
@@ -64,7 +67,10 @@ async fn incorrect_length_pre_handshake() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let test_messages = default_fuzz_messages();
 
@@ -103,7 +109,10 @@ async fn version_with_incorrect_length_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for _ in 0..ITERATIONS {
         let mut synth_node = SyntheticNode::builder()
@@ -182,7 +191,8 @@ async fn version_with_incorrect_length_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -247,7 +257,8 @@ async fn version_with_incorrect_length_inplace_of_verack_when_node_initiates_han
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -266,7 +277,10 @@ async fn version_with_incorrect_length_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for _ in 0..ITERATIONS {
         let mut synth_node = SyntheticNode::builder()
@@ -304,7 +318,10 @@ async fn incorrect_length_during_handshake_responder_side() {
     let mut rng = seeded_rng();
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let test_messages = default_fuzz_messages();
 
@@ -386,7 +403,8 @@ async fn incorrect_body_length_inplace_of_version_when_node_initiates_handshake(
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -453,7 +471,8 @@ async fn incorrect_body_length_inplace_of_verack_when_node_initiates_handshake()
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -472,7 +491,10 @@ async fn incorrect_length_post_handshake() {
 
     let mut rng = seeded_rng();
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     let test_messages = default_fuzz_messages();
 

--- a/src/tests/resistance/fuzzing_incorrect_length.rs
+++ b/src/tests/resistance/fuzzing_incorrect_length.rs
@@ -54,7 +54,7 @@ async fn version_with_incorrect_length_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -96,7 +96,7 @@ async fn incorrect_length_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -137,7 +137,7 @@ async fn version_with_incorrect_length_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -199,7 +199,7 @@ async fn version_with_incorrect_length_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -265,7 +265,7 @@ async fn version_with_incorrect_length_inplace_of_verack_when_node_initiates_han
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -305,7 +305,7 @@ async fn version_with_incorrect_length_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -348,7 +348,7 @@ async fn incorrect_length_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -411,7 +411,7 @@ async fn incorrect_body_length_inplace_of_version_when_node_initiates_handshake(
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -479,7 +479,7 @@ async fn incorrect_body_length_inplace_of_verack_when_node_initiates_handshake()
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -521,7 +521,7 @@ async fn incorrect_length_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 fn encode_with_corrupt_body_length(rng: &mut ChaCha8Rng, message: &Message) -> Vec<u8> {

--- a/src/tests/resistance/fuzzing_random_bytes.rs
+++ b/src/tests/resistance/fuzzing_random_bytes.rs
@@ -25,7 +25,10 @@ async fn random_bytes_pre_handshake() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()
@@ -60,7 +63,10 @@ async fn random_bytes_during_handshake_responder_side() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()
@@ -138,7 +144,8 @@ async fn random_bytes_for_version_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -200,7 +207,8 @@ async fn random_bytes_for_verack_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -221,7 +229,10 @@ async fn random_bytes_post_handshake() {
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()
@@ -260,7 +271,10 @@ async fn metadata_compliant_random_bytes_pre_handshake() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()
@@ -297,7 +311,10 @@ async fn metadata_compliant_random_bytes_during_handshake_responder_side() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()
@@ -375,7 +392,8 @@ async fn metadata_compliant_random_bytes_for_version_when_node_initiates_handsha
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -442,7 +460,8 @@ async fn metadata_compliant_random_bytes_for_verack_when_node_initiates_handshak
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -465,7 +484,10 @@ async fn metadata_compliant_random_bytes_post_handshake() {
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()

--- a/src/tests/resistance/fuzzing_random_bytes.rs
+++ b/src/tests/resistance/fuzzing_random_bytes.rs
@@ -49,7 +49,7 @@ async fn random_bytes_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -90,7 +90,7 @@ async fn random_bytes_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -152,7 +152,7 @@ async fn random_bytes_for_version_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -215,7 +215,7 @@ async fn random_bytes_for_verack_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -255,7 +255,7 @@ async fn random_bytes_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -295,7 +295,7 @@ async fn metadata_compliant_random_bytes_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -336,7 +336,7 @@ async fn metadata_compliant_random_bytes_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -400,7 +400,7 @@ async fn metadata_compliant_random_bytes_for_version_when_node_initiates_handsha
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -468,7 +468,7 @@ async fn metadata_compliant_random_bytes_for_verack_when_node_initiates_handshak
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -509,7 +509,7 @@ async fn metadata_compliant_random_bytes_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 // Random length, random bytes.

--- a/src/tests/resistance/fuzzing_stress.rs
+++ b/src/tests/resistance/fuzzing_stress.rs
@@ -227,7 +227,8 @@ async fn throughput() {
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .max_peers(synth_counts.iter().max().unwrap() * 2 + 10)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     let node_addr = node.addr();
 

--- a/src/tests/resistance/fuzzing_stress.rs
+++ b/src/tests/resistance/fuzzing_stress.rs
@@ -382,7 +382,7 @@ async fn throughput() {
     println!("Request latencies\n{}\n", request_table);
     println!("Handshake latencies\n{}\n", handshake_table);
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 // A list of valid queries and their expected responses

--- a/src/tests/resistance/fuzzing_zeroes.rs
+++ b/src/tests/resistance/fuzzing_zeroes.rs
@@ -47,7 +47,7 @@ async fn zeroes_pre_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -88,7 +88,7 @@ async fn zeroes_during_handshake_responder_side() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -151,7 +151,7 @@ async fn zeroes_for_version_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -217,7 +217,7 @@ async fn zeroes_for_verack_when_node_initiates_handshake() {
         handle.await.unwrap().unwrap();
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 #[tokio::test]
@@ -257,7 +257,7 @@ async fn zeroes_post_handshake() {
             .is_ok());
     }
 
-    node.stop().await;
+    node.stop().await.unwrap();
 }
 
 // Random length zeroes.

--- a/src/tests/resistance/fuzzing_zeroes.rs
+++ b/src/tests/resistance/fuzzing_zeroes.rs
@@ -22,7 +22,10 @@ async fn zeroes_pre_handshake() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()
@@ -58,7 +61,10 @@ async fn zeroes_during_handshake_responder_side() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()
@@ -137,7 +143,8 @@ async fn zeroes_for_version_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -202,7 +209,8 @@ async fn zeroes_for_verack_when_node_initiates_handshake() {
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
-        .await;
+        .await
+        .unwrap();
 
     // join the peer processes
     for handle in synth_handles {
@@ -223,7 +231,10 @@ async fn zeroes_post_handshake() {
     let payloads = zeroes(&mut rng, ITERATIONS);
 
     let mut node: Node = Default::default();
-    node.initial_action(Action::WaitForConnection).start().await;
+    node.initial_action(Action::WaitForConnection)
+        .start()
+        .await
+        .unwrap();
 
     for payload in payloads {
         let mut synth_node = SyntheticNode::builder()

--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -21,7 +21,7 @@ use tokio::{
 use tracing::*;
 
 use std::{
-    io::{Cursor, Error, ErrorKind, self},
+    io::{self, Cursor, Error, ErrorKind},
     net::{IpAddr, Ipv4Addr, SocketAddr},
     time::Duration,
 };
@@ -193,7 +193,11 @@ impl SyntheticNode {
     }
 
     /// Sends a direct message to the target address.
-    pub async fn send_direct_message(&self, target: SocketAddr, message: Message) -> io::Result<()> {
+    pub async fn send_direct_message(
+        &self,
+        target: SocketAddr,
+        message: Message,
+    ) -> io::Result<()> {
         self.inner_node.send_direct_message(target, message).await?;
 
         Ok(())

--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -452,7 +452,7 @@ impl Handshaking for InnerNode {
     async fn perform_handshake(&self, mut conn: Connection) -> io::Result<Connection> {
         match (self.handshake, !conn.side) {
             (Some(Handshake::Full), ConnectionSide::Initiator) => {
-                // Possible bug: running zebra node io::Results in internal pea2pea panics:
+                // Possible bug: running zebra node results in internal pea2pea panics:
                 //  "thread 'tokio-runtime-worker' panicked at 'internal error: entered unreachable code'"
                 // which gets "fixed" by reversing the parameters in Version::new -- no current insight into
                 // why this is the case. The panic is triggered by the following code in pea2pea:


### PR DESCRIPTION
Removes `unwrap` in various `Node` functions in favour of returning an `io::Result`. 
Also renames `message::io` -> `message::stream_io` for clarity. 