### PR TITLE
ref: config error handling

### DIFF
--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -65,7 +65,7 @@ impl Default for Node {
     fn default() -> Self {
         // Config (to be written to node configuration file).
         let config = NodeConfig::new();
-        let meta = NodeMetaData::new();
+        let meta = NodeMetaData::new().unwrap();
 
         Self {
             config,
@@ -76,6 +76,18 @@ impl Default for Node {
 }
 
 impl Node {
+    pub fn new() -> io::Result<Self> {
+        // Config (to be written to node configuration file).
+        let config = NodeConfig::new();
+        let meta = NodeMetaData::new()?;
+
+        Ok(Self {
+            config,
+            meta,
+            process: None,
+        })
+    }
+
     /// Returns the (external) address of the node.
     pub fn addr(&self) -> SocketAddr {
         self.config.local_addr
@@ -116,7 +128,7 @@ impl Node {
     /// provided in `config.toml`.
     pub async fn start(&mut self) -> io::Result<()> {
         // cleanup any previous runs (node.stop won't always be reached e.g. test panics, or SIGINT)
-        self.cleanup();
+        self.cleanup()?;
 
         // Setup the listener if there is some initial action required
         let synthetic_node = match self.config.initial_action {
@@ -263,7 +275,7 @@ impl Node {
                 Some(exit_code) => Some(format!("crashed with {}", exit_code)),
             };
 
-            self.cleanup();
+            self.cleanup()?;
 
             if let Some(crash_msg) = crashed {
                 panic!("Node exited early, {}", crash_msg);
@@ -276,7 +288,8 @@ impl Node {
     fn generate_config_file(&self) -> io::Result<()> {
         let path = self.config_filepath();
         let content = match self.meta.kind {
-            NodeKind::Zebra => ZebraConfigFile::generate(&self.config),
+            NodeKind::Zebra => ZebraConfigFile::generate(&self.config)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
             NodeKind::Zcashd => ZcashdConfigFile::generate(&self.config),
         };
 
@@ -290,35 +303,34 @@ impl Node {
         }
     }
 
-    fn cleanup(&self) {
-        self.cleanup_config_file();
-        self.cleanup_cache();
+    fn cleanup(&self) -> io::Result<()> {
+        self.cleanup_config_file()?;
+        self.cleanup_cache()
     }
 
-    fn cleanup_config_file(&self) {
+    fn cleanup_config_file(&self) -> io::Result<()> {
         let path = self.config_filepath();
-        match std::fs::remove_file(path) {
-            // File may not exist, so we let that error through
-            Err(err) if err.kind() != std::io::ErrorKind::NotFound => {
-                panic!("Error removing config file: {}", err)
-            }
-            _ => {}
+        match fs::remove_file(path) {
+            // File may not exist, so we surpress the error.
+            Err(e) if e.kind() != std::io::ErrorKind::NotFound => Err(e),
+            _ => Ok(()),
         }
     }
 
-    fn cleanup_cache(&self) {
+    fn cleanup_cache(&self) -> io::Result<()> {
         // No cache for zebra as it is configured in ephemeral mode
-        if let NodeKind::Zcashd = self.meta.kind {
+        if let (NodeKind::Zcashd, Some(path)) = (self.meta.kind, home::home_dir()) {
             // Default cache location is ~/.zcash
-            let path = home::home_dir().unwrap().join(".zcash");
+            let path = path.join(".zcash");
 
-            match std::fs::remove_dir_all(path) {
+            if let Err(e) = fs::remove_dir_all(path) {
                 // Directory may not exist, so we let that error through
-                Err(err) if err.kind() != std::io::ErrorKind::NotFound => {
-                    panic!("Error cleaning up zcashd cache: {}", err)
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    return Err(e);
                 }
-                _ => {}
             }
         }
+
+        Ok(())
     }
 }

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -52,7 +52,7 @@ pub struct Node {
     process: Option<Child>,
 }
 
-impl Default for Node {
+impl Node {
     /// Creates a new [`Node`] instance.
     ///
     /// Once created, it can be configured with calls to [`initial_peers`], [`max_peers`] and [`log_to_stdout`].
@@ -62,20 +62,6 @@ impl Default for Node {
     /// [`initial_peers`]: method@Node::initial_peers
     /// [`max_peers`]: method@Node::max_peers
     /// [`log_to_stdout`]: method@Node::log_to_stdout
-    fn default() -> Self {
-        // Config (to be written to node configuration file).
-        let config = NodeConfig::new();
-        let meta = NodeMetaData::new().unwrap();
-
-        Self {
-            config,
-            meta,
-            process: None,
-        }
-    }
-}
-
-impl Node {
     pub fn new() -> io::Result<Self> {
         // Config (to be written to node configuration file).
         let config = NodeConfig::new();

--- a/src/tests/conformance/handshake.rs
+++ b/src/tests/conformance/handshake.rs
@@ -21,7 +21,7 @@ async fn handshake_responder_side() {
     // ZG-CONFORMANCE-001
 
     // Spin up a node instance.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -57,7 +57,7 @@ async fn handshake_initiator_side() {
         .unwrap();
 
     // Spin up a node and set the synthetic node as an initial peer.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_peers(vec![synthetic_node.listening_addr()])
         .start()
         .await
@@ -102,7 +102,7 @@ async fn ignore_non_version_before_handshake() {
     ];
 
     // Spin up a node instance.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -192,7 +192,7 @@ async fn ignore_non_version_replies_to_version() {
         .await
         .unwrap();
     // Instantiate a node instance without starting it (so we have access to its addr).
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     let node_addr = node.addr();
 
     // Create a future for each message.
@@ -283,7 +283,7 @@ async fn ignore_non_verack_replies_to_verack() {
         .unwrap();
 
     // Instantiate a node instance without starting it (so we have access to its addr).
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     let node_addr = node.addr();
 
     // Create a future for each message.
@@ -361,7 +361,7 @@ async fn reject_version_reusing_nonce() {
     let mut synthetic_node = SyntheticNode::builder().build().await.unwrap();
 
     // Spin up a node instance with the synthetic node set as an initial peer.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_peers(vec![synthetic_node.listening_addr()])
         .start()
         .await
@@ -399,7 +399,7 @@ async fn reject_obsolete_versions() {
     let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
 
     // Spin up a node instance.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -60,7 +60,7 @@ async fn reject_invalid_messages() {
     //     FilterClear:        ignored
 
     // Spin up a node instance (so we have acces to its addr).
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -135,7 +135,7 @@ async fn ignores_unsolicited_responses() {
     //      3. Receive a pong response
 
     // Spin up a node instance.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -207,7 +207,7 @@ async fn basic_query_response_seeded() {
     let genesis_block = Block::testnet_genesis();
 
     // Spin up a node instance.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .start()
         .await
@@ -354,7 +354,7 @@ async fn basic_query_response_unseeded() {
     ];
 
     // Spin up a node instance.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -421,7 +421,7 @@ async fn disconnects_for_trivial_issues() {
     //      Pong            - ignores the message
 
     // Spin up a node instance.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -522,7 +522,7 @@ async fn eagerly_crawls_network_for_peers() {
     //                         https://github.com/ZcashFoundation/zebra/issues/2163
 
     // Spin up a node instance.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -616,7 +616,7 @@ async fn correctly_lists_peers() {
     let (synthetic_nodes, expected_addrs) = node_builder.build_n(N).await.unwrap();
 
     // Start node with the synthetic nodes as initial peers.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .initial_peers(expected_addrs.clone())
         .start()
@@ -685,7 +685,7 @@ async fn get_blocks() {
     // Note: zcashd ignores requests for the final block in the chain
 
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .start()
         .await
@@ -825,7 +825,7 @@ async fn correctly_lists_blocks() {
     //  zebra: does not support seeding as yet, and therefore cannot perform this test.
 
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .start()
         .await
@@ -949,7 +949,7 @@ async fn get_data_blocks() {
     //  zebra: does not support seeding as yet, and therefore cannot perform this test.
 
     // Create a node with knowledge of the initial three testnet blocks
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .start()
         .await

--- a/src/tests/conformance/messages.rs
+++ b/src/tests/conformance/messages.rs
@@ -988,10 +988,10 @@ async fn get_data_blocks() {
             .unwrap();
 
         // Expect the i blocks
-        for j in 0..=i {
+        for (j, expected_block) in blocks.iter().enumerate().take(i + 1) {
             let (_, block) = synthetic_node.recv_message_timeout(TIMEOUT).await.unwrap();
             let block = assert_matches!(block, Message::Block(block) => block);
-            assert_eq!(block, blocks[j], "run {}, {}", i, j);
+            assert_eq!(block, *expected_block, "run {}, {}", i, j);
         }
     }
 

--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -120,7 +120,7 @@ async fn load_bearing() {
     let mut all_stats = Vec::new();
 
     // start node
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .max_peers(MAX_PEERS as usize)
         .start()

--- a/src/tests/performance/getdata_blocks.rs
+++ b/src/tests/performance/getdata_blocks.rs
@@ -87,7 +87,7 @@ async fn throughput() {
 
     // Start node seeded with initial testnet blocks,
     // with max peers set so that our peers should never be rejected.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .max_peers(synth_counts.iter().max().unwrap() * 2 + 10)
         .start()

--- a/src/tests/performance/ping_pong.rs
+++ b/src/tests/performance/ping_pong.rs
@@ -123,7 +123,7 @@ async fn throughput() {
 
     // start node, with max peers set so that our peers should
     // never be rejected.
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .max_peers(synth_counts.iter().max().unwrap() * 2 + 10)
         .start()

--- a/src/tests/resistance/fuzzing_corrupted_messages.rs
+++ b/src/tests/resistance/fuzzing_corrupted_messages.rs
@@ -25,7 +25,7 @@ async fn corrupted_messages_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -63,7 +63,7 @@ async fn corrupted_messages_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -140,7 +140,7 @@ async fn corrupted_messages_inplace_of_version_when_node_initiates_handshake() {
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -206,7 +206,7 @@ async fn corrupted_messages_inplace_of_verack_when_node_initiates_handshake() {
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -233,7 +233,7 @@ async fn corrupted_messages_post_handshake() {
     let mut rng = seeded_rng();
     let payloads = slightly_corrupted_messages(&mut rng, ITERATIONS, &test_messages);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await

--- a/src/tests/resistance/fuzzing_corrupted_messages.rs
+++ b/src/tests/resistance/fuzzing_corrupted_messages.rs
@@ -271,7 +271,7 @@ pub fn slightly_corrupted_messages(
     (0..n)
         .map(|_| {
             let message = messages.choose(rng).unwrap();
-            corrupt_message(rng, &message)
+            corrupt_message(rng, message)
         })
         .collect()
 }

--- a/src/tests/resistance/fuzzing_incorrect_checksum.rs
+++ b/src/tests/resistance/fuzzing_incorrect_checksum.rs
@@ -23,7 +23,7 @@ async fn incorrect_checksum_pre_handshake() {
 
     let mut rng = seeded_rng();
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -72,7 +72,7 @@ async fn incorrect_checksum_during_handshake_responder_side() {
 
     let mut rng = seeded_rng();
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -161,7 +161,7 @@ async fn incorrect_checksum_inplace_of_version_when_node_initiates_handshake() {
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -226,7 +226,7 @@ async fn incorrect_checksum_inplace_of_verack_when_node_initiates_handshake() {
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -249,7 +249,7 @@ async fn incorrect_checksum_post_handshake() {
     // zcashd: logs indicate message was ignored, doesn't disconnect.
 
     let mut rng = seeded_rng();
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await

--- a/src/tests/resistance/fuzzing_incorrect_length.rs
+++ b/src/tests/resistance/fuzzing_incorrect_length.rs
@@ -294,7 +294,7 @@ pub fn encode_messages_and_corrupt_body_length_field(
         .map(|_| {
             let message = message_pool.choose(rng).unwrap();
 
-            encode_with_corrupt_body_length(rng, &message)
+            encode_with_corrupt_body_length(rng, message)
         })
         .collect()
 }

--- a/src/tests/resistance/fuzzing_incorrect_length.rs
+++ b/src/tests/resistance/fuzzing_incorrect_length.rs
@@ -23,7 +23,7 @@ async fn incorrect_length_pre_handshake() {
 
     let mut rng = seeded_rng();
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -65,7 +65,7 @@ async fn incorrect_length_during_handshake_responder_side() {
 
     let mut rng = seeded_rng();
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -147,7 +147,7 @@ async fn incorrect_body_length_inplace_of_version_when_node_initiates_handshake(
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -215,7 +215,7 @@ async fn incorrect_body_length_inplace_of_verack_when_node_initiates_handshake()
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -238,7 +238,7 @@ async fn incorrect_length_post_handshake() {
     // zcashd: disconnects (sometimes sends ping and getheaders)
 
     let mut rng = seeded_rng();
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await

--- a/src/tests/resistance/fuzzing_random_bytes.rs
+++ b/src/tests/resistance/fuzzing_random_bytes.rs
@@ -24,7 +24,7 @@ async fn random_bytes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -62,7 +62,7 @@ async fn random_bytes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -140,7 +140,7 @@ async fn random_bytes_for_version_when_node_initiates_handshake() {
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -203,7 +203,7 @@ async fn random_bytes_for_verack_when_node_initiates_handshake() {
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -228,7 +228,7 @@ async fn random_bytes_post_handshake() {
     let mut rng = seeded_rng();
     let payloads = random_bytes(&mut rng, ITERATIONS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -270,7 +270,7 @@ async fn metadata_compliant_random_bytes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -310,7 +310,7 @@ async fn metadata_compliant_random_bytes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -388,7 +388,7 @@ async fn metadata_compliant_random_bytes_for_version_when_node_initiates_handsha
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -456,7 +456,7 @@ async fn metadata_compliant_random_bytes_for_verack_when_node_initiates_handshak
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -483,7 +483,7 @@ async fn metadata_compliant_random_bytes_post_handshake() {
     let mut rng = seeded_rng();
     let payloads = metadata_compliant_random_bytes(&mut rng, ITERATIONS, &COMMANDS_WITH_PAYLOADS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await

--- a/src/tests/resistance/fuzzing_stress.rs
+++ b/src/tests/resistance/fuzzing_stress.rs
@@ -223,7 +223,7 @@ async fn throughput() {
     // Start node with arbitrarily higher max peer count than what we
     // need for the test. Note that zcashd node appears to reserver 8
     // slots (hence the +10).
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::SeedWithTestnetBlocks(3))
         .max_peers(synth_counts.iter().max().unwrap() * 2 + 10)
         .start()

--- a/src/tests/resistance/fuzzing_zeroes.rs
+++ b/src/tests/resistance/fuzzing_zeroes.rs
@@ -21,7 +21,7 @@ async fn zeroes_pre_handshake() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -60,7 +60,7 @@ async fn zeroes_during_handshake_responder_side() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await
@@ -139,7 +139,7 @@ async fn zeroes_for_version_when_node_initiates_handshake() {
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -205,7 +205,7 @@ async fn zeroes_for_verack_when_node_initiates_handshake() {
         ));
     }
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::None)
         .initial_peers(synth_addrs)
         .start()
@@ -230,7 +230,7 @@ async fn zeroes_post_handshake() {
     let mut rng = seeded_rng();
     let payloads = zeroes(&mut rng, ITERATIONS);
 
-    let mut node: Node = Default::default();
+    let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
         .start()
         .await


### PR DESCRIPTION
Removes `unwrap` in various config utility functions. Also addresses a few clippy lints on test targets as a fly-by. 