### PR TITLE
ci: include tests in clippy checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: --all-targets -- -D warnings
 
 
   rustfmt:


### PR DESCRIPTION
The fixes for the failing lints are included in #80. 