### PR TITLE
feat: automated node config path args

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Ziggurat is configured with a `config.toml` file in the root.
 ```toml
 kind = "zebra"
 path = "path/to/zebra/repo"
-start_command = "cargo +stable r -- --config zebra.toml --verbose start"
+start_command = "cargo +stable r -- --verbose start"
 
 # kind = "zcashd"
 # path = "path/to/zcash/repo"
-# start_command = "./src/zcashd -debug=1 -dnsseed=0 -printtoconsole -logips=1 -listenonion=0 -dns=0 -conf=/path/to/zcash/repo/zcash.conf"
+# start_command = "./src/zcashd -debug=1 -dnsseed=0 -printtoconsole -logips=1 -listenonion=0 -dns=0"
 ```
 
 Information about the node to be tested can be set under the `[node]` table:

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -110,10 +110,15 @@ impl NodeMetaData {
         match config_file.kind {
             NodeKind::Zebra => {
                 // Zebra's final arg must be `start`, so we insert the actual args before it.
-                let n = start_args.len();
-                assert!(n > 1, "Expected at least one arg for Zebra (`start`)");
-                start_args.insert(n - 1, "--config".into());
-                start_args.insert(n, config_path.into_os_string());
+                let n_args = start_args.len();
+                if n_args < 1 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "Expected at least one start_command arg for Zebra (`start`)",
+                    ));
+                }
+                start_args.insert(n_args - 1, "--config".into());
+                start_args.insert(n_args, config_path.into_os_string());
             }
             NodeKind::Zcashd => {
                 start_args.push(format!("-conf={}", config_path.to_str().unwrap()).into());

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -303,8 +303,8 @@ impl Node {
 
     fn config_filepath(&self) -> std::path::PathBuf {
         match self.meta.kind {
-            NodeKind::Zebra => self.meta.path.join(ZEBRA_CONFIG),
-            NodeKind::Zcashd => self.meta.path.join(ZCASHD_CONFIG),
+            NodeKind::Zebra => std::env::current_dir().unwrap().join(ZEBRA_CONFIG),
+            NodeKind::Zcashd => std::env::current_dir().unwrap().join(ZCASHD_CONFIG),
         }
     }
 

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -76,17 +76,12 @@ impl Node {
         // insert the config file cmd args
         match node.meta.kind {
             NodeKind::Zebra => {
-                // Bit more convoluted since we need to insert the args before `start`, which comes last.
-                let start_arg = node
-                    .meta
-                    .start_args
-                    .pop()
-                    .expect("Expected at least one arg for Zebra (`start`)");
-                node.meta.start_args.push("--config".into());
+                let n = node.meta.start_args.len();
+                assert!(n > 1, "Expected at least one arg for Zebra (`start`)");
+                node.meta.start_args.insert(n - 1, "--config".into());
                 node.meta
                     .start_args
-                    .push(node.config_filepath().into_os_string());
-                node.meta.start_args.push(start_arg);
+                    .insert(n, node.config_filepath().into_os_string());
             }
             NodeKind::Zcashd => {
                 node.meta


### PR DESCRIPTION
The user previously had to specify the location of our generated config file. This change removes this requirement -- since we generate it, we should also pass on the information to the node.