### PR TITLE
chore: disable malfunctioning clippy lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::nonstandard_macro_braces)]
+
 pub mod protocol;
 pub mod setup;
 pub mod tools;


### PR DESCRIPTION
clippy::nonstandard_macro_braces