### PR TITLE
feat: move configuration and node caches to `~/.ziggurat` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Similarly to `zcashd`, configuration is not necessary since Ziggurat generates n
 
 ## Configuration
 
-Ziggurat is configured via a `config.toml` file in the root directory. It must contain the following fields:
+Ziggurat is configured via a `config.toml` file in the `~/.ziggurat` directory (you'll need to create this yourself). It must contain the following fields:
 
 - `kind`: one of `zebra` or `zcashd`.
 - `path`: absolute path in which to run the start command.

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -112,7 +112,7 @@ impl NodeMetaData {
         let start_command = start_args.remove(0);
 
         // Insert the node's config file path into start args.
-        let config_path = config_file.kind.config_filepath(&config_path);
+        let config_file_path = config_file.kind.config_filepath(&config_path);
         match config_file.kind {
             NodeKind::Zebra => {
                 // Zebra's final arg must be `start`, so we insert the actual args before it.
@@ -124,7 +124,7 @@ impl NodeMetaData {
                     ));
                 }
                 start_args.insert(n_args - 1, "--config".into());
-                start_args.insert(n_args, config_path.into_os_string());
+                start_args.insert(n_args, config_file_path.into_os_string());
             }
             NodeKind::Zcashd => {
                 start_args.push(format!("-datadir={}", config_path.to_str().unwrap()).into());

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -16,7 +16,10 @@ const ZEBRA_CONFIG: &str = "zebra.toml";
 const ZCASHD_CONFIG: &str = "zcash.conf";
 const ZCASHD_CACHE: &str = "testnet3";
 
-const CONFIG: &str = "config.toml";
+// Ziggurat's configuration directory and file. Caches are written to this directory.
+const CONFIG: &str = ".ziggurat";
+const CONFIG_FILE: &str = "config.toml";
+
 const DEFAULT_PORT: u16 = 8080;
 
 /// Convenience struct for reading Ziggurat's configuration file.
@@ -57,7 +60,7 @@ impl NodeConfig {
         Ok(Self {
             path: home::home_dir()
                 .ok_or_else(|| Error::new(ErrorKind::NotFound, "couldn't find home directory"))?
-                .join(".ziggurat"),
+                .join(CONFIG),
             local_addr,
             initial_peers: HashSet::new(),
             max_peers: 50,
@@ -108,7 +111,7 @@ pub(super) struct NodeMetaData {
 impl NodeMetaData {
     pub(super) fn new(config_path: PathBuf) -> io::Result<Self> {
         // Read Ziggurat's configuration file.
-        let path = config_path.join(CONFIG);
+        let path = config_path.join(CONFIG_FILE);
         let config_string = fs::read_to_string(path)?;
         let config_file: ConfigFile = toml::from_str(&config_string)?;
 

--- a/src/setup/config.rs
+++ b/src/setup/config.rs
@@ -14,6 +14,7 @@ use crate::setup::node::Action;
 // The names of the files the node configurations will be written to.
 const ZEBRA_CONFIG: &str = "zebra.toml";
 const ZCASHD_CONFIG: &str = "zcash.conf";
+const ZCASHD_CACHE: &str = "testnet3";
 
 const CONFIG: &str = "config.toml";
 const DEFAULT_PORT: u16 = 8080;
@@ -80,6 +81,13 @@ impl NodeKind {
         match self {
             NodeKind::Zebra => wrapping_dir.join(ZEBRA_CONFIG),
             NodeKind::Zcashd => wrapping_dir.join(ZCASHD_CONFIG),
+        }
+    }
+
+    pub(super) fn cache_path(&self, wrapping_dir: &Path) -> Option<PathBuf> {
+        match self {
+            NodeKind::Zebra => None,
+            NodeKind::Zcashd => Some(wrapping_dir.join(ZCASHD_CACHE)),
         }
     }
 }

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -308,9 +308,7 @@ impl Node {
 
     fn cleanup_cache(&self) -> io::Result<()> {
         // Zebra doesn't currently use a cache as it's configured in ephemeral mode.
-        if let NodeKind::Zcashd = self.meta.kind {
-            let path = self.config.path.join("testnet3");
-
+        if let Some(path) = self.meta.kind.cache_path(&self.config.path) {
             if let Err(e) = fs::remove_dir_all(path) {
                 // Directory may not exist, so we let that error through
                 if e.kind() != std::io::ErrorKind::NotFound {


### PR DESCRIPTION
Supersedes #104 and closes #103. 