### PR TITLE
docs: build optimised Zebra with locked dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,7 @@ After completing the above, you can skip the configuration steps, i.e. creating 
 
 ```bash
 # After installing dependencies
-$ git clone https://github.com/ZcashFoundation/zebra
-$ cd zebra
-$ cargo +stable build
+$ cargo +stable install --locked --git https://github.com/ZcashFoundation/zebra
 ```
 
 Similarly to `zcashd`, configuration is not necessary since Ziggurat generates new configurations for each test run.


### PR DESCRIPTION
This PR updates the Zebra build command to match the Zebra README:
https://github.com/ZcashFoundation/zebra#build-and-run-instructions

This change has the following impacts:
* `--install` builds Zebra in release mode
* `--locked` builds Zebra with tested dependency versions (rather than the latest dependency versions)