### PR TITLE
Feat: update the network protocol version number to Nu5

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and [zebra](https://github.com/ZcashFoundation/zebra) devs with this reliable fo
 
 Ziggurat is written in stable Rust; you can install the Rust toolchain by following the official instructions [here](*https://www.rust-lang.org/learn/get-started).
 
-You also need to install at least one node implementation to test.
+You also need to install at least one node implementation to test. Ziggurat is currently configured to test the Nu5 network protocol (version `170_015`).
 
 ### Zcashd
 

--- a/src/protocol/message/constants.rs
+++ b/src/protocol/message/constants.rs
@@ -8,6 +8,8 @@ pub const HEADER_LEN: usize = 24;
 /// Maximum message length (2 MiB).
 pub const MAX_MESSAGE_LEN: usize = 2 * 1024 * 1024;
 
+/// The current network protocol version number.
+pub const PROTOCOL_VERSION: u32 = 170_015;
 /// The current network version identifier.
 pub const MAGIC: [u8; 4] = [0xfa, 0x1a, 0xf9, 0xbf];
 

--- a/src/protocol/payload/mod.rs
+++ b/src/protocol/payload/mod.rs
@@ -23,7 +23,7 @@ pub use version::Version;
 pub mod reject;
 pub use reject::Reject;
 
-use crate::protocol::message::constants::MAX_MESSAGE_LEN;
+use crate::protocol::message::constants::{MAX_MESSAGE_LEN, PROTOCOL_VERSION};
 
 use self::codec::Codec;
 
@@ -63,7 +63,7 @@ pub struct ProtocolVersion(u32);
 impl ProtocolVersion {
     /// The current protocol version.
     pub fn current() -> Self {
-        Self(170_013)
+        Self(PROTOCOL_VERSION)
     }
 }
 


### PR DESCRIPTION
Changes the version number to `170_015` and introduces a constant holding the value. This has also been documented in the README. Closes #110.

Branch based on #113, only the last commit is new.