### PR TITLE
Add a fuzz test for the synthetic node impl

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ziggurat-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+tokio-util = { version = "0.7", features = ["codec"] }
+
+[dependencies.ziggurat]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "decoder"
+path = "fuzz_targets/decoder.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/decoder.rs
+++ b/fuzz/fuzz_targets/decoder.rs
@@ -1,0 +1,10 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use tokio_util::codec::Decoder;
+use ziggurat::tools::synthetic_node::MessageCodec;
+
+fuzz_target!(|data: &[u8]| {
+    let mut codec = MessageCodec::default();
+    let _ = codec.decode(&mut data.into());
+});

--- a/src/protocol/payload/addr.rs
+++ b/src/protocol/payload/addr.rs
@@ -86,6 +86,10 @@ impl NetworkAddr {
     pub(super) fn decode_without_timestamp<B: Buf>(bytes: &mut B) -> io::Result<Self> {
         let services = u64::from_le_bytes(read_n_bytes(bytes)?);
 
+        if bytes.remaining() < 16 {
+            return Err(io::ErrorKind::InvalidData.into());
+        }
+
         let mut octets = [0u8; 16];
         bytes.copy_to_slice(&mut octets);
         let v6_addr = Ipv6Addr::from(octets);

--- a/src/protocol/payload/codec.rs
+++ b/src/protocol/payload/codec.rs
@@ -32,8 +32,6 @@ impl<T: Codec> Codec for Vec<T> {
         Self: Sized,
     {
         let length = *VarInt::decode(bytes)?;
-        (0..length)
-            .map(|_| T::decode(bytes))
-            .collect::<io::Result<Self>>()
+        (0..length).map(|_| T::decode(bytes)).collect()
     }
 }

--- a/src/protocol/payload/mod.rs
+++ b/src/protocol/payload/mod.rs
@@ -50,6 +50,9 @@ impl Codec for Nonce {
     }
 
     fn decode<B: Buf>(bytes: &mut B) -> io::Result<Self> {
+        if bytes.remaining() < 8 {
+            return Err(io::ErrorKind::InvalidData.into());
+        }
         let nonce = bytes.get_u64_le();
 
         Ok(Self(nonce))

--- a/src/protocol/payload/tx.rs
+++ b/src/protocol/payload/tx.rs
@@ -182,7 +182,7 @@ impl Codec for TxV2 {
         let lock_time = u32::from_le_bytes(read_n_bytes(bytes)?);
 
         let join_split_count = *VarInt::decode(bytes)?;
-        let mut join_split = Vec::with_capacity(join_split_count);
+        let mut join_split = Vec::new();
 
         for _ in 0..join_split_count {
             let description = JoinSplit::decode_bctv14(bytes)?;
@@ -269,7 +269,7 @@ impl Codec for TxV3 {
         let expiry_height = u32::from_le_bytes(read_n_bytes(bytes)?);
 
         let join_split_count = *VarInt::decode(bytes)?;
-        let mut join_split = Vec::with_capacity(join_split_count);
+        let mut join_split = Vec::new();
 
         for _ in 0..join_split_count {
             let description = JoinSplit::decode_bctv14(bytes)?;
@@ -378,7 +378,7 @@ impl Codec for TxV4 {
         let outputs_sapling = Vec::<OutputDescriptionV4>::decode(bytes)?;
 
         let join_split_count = VarInt::decode(bytes)?;
-        let mut join_split = Vec::with_capacity(*join_split_count);
+        let mut join_split = Vec::new();
 
         for _ in 0..*join_split_count {
             let description = JoinSplit::decode_groth16(bytes)?;
@@ -550,19 +550,19 @@ impl Codec for TxV5 {
         };
 
         // Decode spend proofs sapling.
-        let mut spend_proofs_sapling = Vec::with_capacity(spends_sapling.len());
+        let mut spend_proofs_sapling = Vec::new();
         for _ in 0..spends_sapling.len() {
             spend_proofs_sapling.push(read_n_bytes(bytes)?);
         }
 
         // Decode spend auth sigs.
-        let mut spend_auth_sigs_sapling = Vec::with_capacity(spends_sapling.len());
+        let mut spend_auth_sigs_sapling = Vec::new();
         for _ in 0..spends_sapling.len() {
             spend_auth_sigs_sapling.push(read_n_bytes(bytes)?);
         }
 
         // Decode output proofs.
-        let mut output_proofs_sapling = Vec::with_capacity(spends_sapling.len());
+        let mut output_proofs_sapling = Vec::new();
         for _ in 0..spends_sapling.len() {
             output_proofs_sapling.push(read_n_bytes(bytes)?);
         }
@@ -605,13 +605,13 @@ impl Codec for TxV5 {
                 return Err(io::ErrorKind::InvalidData.into());
             }
 
-            let mut proofs_orchard = Vec::with_capacity(*n_proofs_orchard);
+            let mut proofs_orchard = Vec::new();
             for _ in 0..*n_proofs_orchard {
                 proofs_orchard.push(bytes.get_u8());
             }
 
             // Decode orchard auth sigs.
-            let mut auth_sigs_orchard = Vec::with_capacity(actions_orchard.len());
+            let mut auth_sigs_orchard = Vec::new();
             for _ in 0..actions_orchard.len() {
                 auth_sigs_orchard.push(read_n_bytes(bytes)?);
             }

--- a/src/protocol/payload/tx.rs
+++ b/src/protocol/payload/tx.rs
@@ -518,6 +518,10 @@ impl Codec for TxV5 {
     }
 
     fn decode<B: Buf>(bytes: &mut B) -> io::Result<Self> {
+        if bytes.remaining() < 16 {
+            return Err(io::ErrorKind::InvalidData.into());
+        }
+
         let group_id = bytes.get_u32_le();
         let consensus_branch = bytes.get_u32_le();
         let lock_time = bytes.get_u32_le();

--- a/src/tools/synthetic_node.rs
+++ b/src/tools/synthetic_node.rs
@@ -410,7 +410,7 @@ impl Pea2Pea for InnerNode {
 }
 
 // TODO: move to protocol
-struct MessageCodec {
+pub struct MessageCodec {
     codec: LengthDelimitedCodec,
 }
 


### PR DESCRIPTION
This PR adds a `decoder` fuzz target that can be used with `cargo-fuzz` (`cargo +nightly fuzz run decoder`) and a few patches that fix issues that I've found with it, now that the synthetic node can be used outside of tests.

Cc @tuommaki