### PR TITLE
Fix: perf test tabled implementations

### DIFF
--- a/src/tests/performance/connections.rs
+++ b/src/tests/performance/connections.rs
@@ -16,22 +16,22 @@ use tokio::sync::mpsc::Sender;
 
 #[derive(Tabled, Default, Debug, Clone)]
 struct Stats {
-    #[header("\n max peers ")]
+    #[tabled(rename = "\n max peers ")]
     pub max_peers: u16,
-    #[header("\n peers ")]
+    #[tabled(rename = "\n peers ")]
     pub peers: u16,
-    #[header(" connection \n accepted ")]
+    #[tabled(rename = " connection \n accepted ")]
     pub accepted: u16,
-    #[header(" connection \n rejected ")]
+    #[tabled(rename = " connection \n rejected ")]
     pub rejected: u16,
-    #[header(" connection \n terminated ")]
+    #[tabled(rename = " connection \n terminated ")]
     pub terminated: u16,
-    #[header(" connection \n error ")]
+    #[tabled(rename = " connection \n error ")]
     pub conn_error: u16,
-    #[header(" connection \n timed out ")]
+    #[tabled(rename = " connection \n timed out ")]
     pub timed_out: u16,
-    #[header("\n time (s) ")]
-    #[field(display_with = "table_float_display")]
+    #[tabled(rename = "\n time (s) ")]
+    #[tabled(display_with = "table_float_display")]
     pub time: f64,
 }
 

--- a/src/tests/resistance/stress_test.rs
+++ b/src/tests/resistance/stress_test.rs
@@ -32,27 +32,27 @@ use crate::{
 struct Stats {
     peers: usize,
     requests: usize,
-    #[header(" handshakes \n accepted ")]
+    #[tabled(rename = " handshakes \n accepted ")]
     handshake_accepted: u16,
-    #[header(" handshakes \n rejected ")]
+    #[tabled(rename = " handshakes \n rejected ")]
     handshake_rejected: u16,
-    #[header(" peers \n dropped ")]
+    #[tabled(rename = " peers \n dropped ")]
     peers_dropped: u16,
-    #[header(" corrupt \n terminated ")]
+    #[tabled(rename = " corrupt \n terminated ")]
     corrupt_terminated: u16,
-    #[header(" corrupt \n rejected ")]
+    #[tabled(rename = " corrupt \n rejected ")]
     corrupt_rejected: u16,
-    #[header(" corrupt \n replied ")]
+    #[tabled(rename = " corrupt \n replied ")]
     corrupt_reply: u16,
-    #[header(" corrupt \n ignored ")]
+    #[tabled(rename = " corrupt \n ignored ")]
     corrupt_ignored: u16,
-    #[header(" bad \n replies ")]
+    #[tabled(rename = " bad \n replies ")]
     reply_errors: u16,
 
-    #[header(" hung \n connections ")]
+    #[tabled(rename = " hung \n connections ")]
     dangling: u16,
-    #[header(" time (s) ")]
-    #[field(display_with = "table_float_display")]
+    #[tabled(rename = " time (s) ")]
+    #[tabled(display_with = "table_float_display")]
     time: f64,
 }
 


### PR DESCRIPTION
Follow-up to #119. Fixes the `tabled` usages in the performance tests that were missed in the previous PR.
