### PR TITLE
Nu5 retest (Zebra)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ These results were obtained by running the test suite against [Zcashd v4.4.1](ht
 | [006](SPEC.md#ZG-CONFORMANCE-006) |   ✓    |   ✓   |                                                                             |
 | [007](SPEC.md#ZG-CONFORMANCE-007) |   ✓    |   ✓   |                                                                             |
 | [008](SPEC.md#ZG-CONFORMANCE-008) |   ✓    |   ✖   |                                                                             |
-| [009](SPEC.md#ZG-CONFORMANCE-009) |   ✖    |   ✖   | ⚠ filters may need work (malformed), ⚠ require zcashd feedback             |
+| [009](SPEC.md#ZG-CONFORMANCE-009) |   ✖    |   ✖   | ⚠ filters may need work (malformed), ⚠ require zcashd feedback              |
 | [010](SPEC.md#ZG-CONFORMANCE-010) |   ✓    |   ✓   |                                                                             |
 | [011](SPEC.md#ZG-CONFORMANCE-011) |   ✖    |   ✖   | ⚠ todo: mempool seeding                                                     |
 | [012](SPEC.md#ZG-CONFORMANCE-012) |   ✖    |   ✖   |                                                                             |

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ These results were obtained by running the test suite against [Zcashd v4.4.1](ht
 | [003](SPEC.md#ZG-CONFORMANCE-003) |   ✓    |   ✖   |                                                                             |
 | [004](SPEC.md#ZG-CONFORMANCE-004) |   ✓    |   ✖   |                                                                             |
 | [005](SPEC.md#ZG-CONFORMANCE-005) |   ✓    |   ✖   |                                                                             |
-| [006](SPEC.md#ZG-CONFORMANCE-006) |   ✓    |   ✖   |                                                                             |
+| [006](SPEC.md#ZG-CONFORMANCE-006) |   ✓    |   ✓   |                                                                             |
 | [007](SPEC.md#ZG-CONFORMANCE-007) |   ✓    |   ✓   |                                                                             |
 | [008](SPEC.md#ZG-CONFORMANCE-008) |   ✓    |   ✖   |                                                                             |
 | [009](SPEC.md#ZG-CONFORMANCE-009) |   ✖    |   ✖   | ⚠ filters may need work (malformed), ⚠ require zcashd feedback             |

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_verack.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_verack.rs
@@ -27,21 +27,21 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn get_addr() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::GetAddr).await.unwrap();
     }
 
     #[tokio::test]
     async fn mempool() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::MemPool).await.unwrap();
     }
 
     #[tokio::test]
     async fn ping() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Ping(Nonce::default()))
             .await
             .unwrap();
@@ -50,7 +50,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn pong() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Pong(Nonce::default()))
             .await
             .unwrap();
@@ -59,7 +59,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn addr() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Addr(Addr::empty())).await.unwrap();
     }
 
@@ -84,7 +84,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn get_data_block() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::GetData(block_inv)).await.unwrap();
     }
@@ -92,7 +92,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn get_data_tx() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::GetData(Inv::new(vec![Block::testnet_genesis()
             .txs[0]
             .inv_hash()])))
@@ -103,7 +103,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn inv() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::Inv(block_inv)).await.unwrap();
     }
@@ -111,7 +111,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn not_found() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::NotFound(block_inv)).await.unwrap();
     }
@@ -174,14 +174,14 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn mempool() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::MemPool).await.unwrap();
     }
 
     #[tokio::test]
     async fn ping() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Ping(Nonce::default()))
             .await
             .unwrap();
@@ -206,7 +206,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn get_headers() {
         // zcashd: pass
-        // zebra:  fail
+        // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
         let block_loc = LocatorHashes::new(vec![block_hash], Hash::zeroed());
         run_test_case(Message::GetHeaders(block_loc)).await.unwrap();
@@ -215,7 +215,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn get_blocks() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
         let block_loc = LocatorHashes::new(vec![block_hash], Hash::zeroed());
         run_test_case(Message::GetBlocks(block_loc)).await.unwrap();
@@ -243,7 +243,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn inv() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::Inv(block_inv)).await.unwrap();
     }
@@ -251,7 +251,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn not_found() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::NotFound(block_inv)).await.unwrap();
     }

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
@@ -27,28 +27,28 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn get_addr() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::GetAddr).await.unwrap();
     }
 
     #[tokio::test]
     async fn mempool() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::MemPool).await.unwrap();
     }
 
     #[tokio::test]
     async fn verack() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Verack).await.unwrap();
     }
 
     #[tokio::test]
     async fn ping() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Ping(Nonce::default()))
             .await
             .unwrap();
@@ -57,7 +57,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn pong() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Pong(Nonce::default()))
             .await
             .unwrap();
@@ -66,7 +66,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn addr() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Addr(Addr::empty())).await.unwrap();
     }
 
@@ -91,7 +91,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn get_data_block() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::GetData(block_inv)).await.unwrap();
     }
@@ -99,7 +99,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn get_data_tx() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::GetData(Inv::new(vec![Block::testnet_genesis()
             .txs[0]
             .inv_hash()])))
@@ -110,7 +110,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn inv() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::Inv(block_inv)).await.unwrap();
     }
@@ -118,7 +118,7 @@ mod when_node_receives_connection {
     #[tokio::test]
     async fn not_found() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::NotFound(block_inv)).await.unwrap();
     }

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
@@ -197,28 +197,28 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn get_addr() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::GetAddr).await.unwrap();
     }
 
     #[tokio::test]
     async fn mempool() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::MemPool).await.unwrap();
     }
 
     #[tokio::test]
     async fn verack() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Verack).await.unwrap();
     }
 
     #[tokio::test]
     async fn ping() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Ping(Nonce::default()))
             .await
             .unwrap();
@@ -227,7 +227,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn pong() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Pong(Nonce::default()))
             .await
             .unwrap();
@@ -236,14 +236,15 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn addr() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::Addr(Addr::empty())).await.unwrap();
     }
 
     #[tokio::test]
     async fn get_headers() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  fail (doesn't disconnect but sends Version instead of Verack), relevant PR:
+        // https://github.com/ZcashFoundation/zebra/pull/3522
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
         let block_loc = LocatorHashes::new(vec![block_hash], Hash::zeroed());
         run_test_case(Message::GetHeaders(block_loc)).await.unwrap();
@@ -252,7 +253,8 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn get_blocks() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  fail (doesn't disconnect but sends Version instead of Verack), relevant PR:
+        // https://github.com/ZcashFoundation/zebra/pull/3522
         let block_hash = Block::testnet_genesis().double_sha256().unwrap();
         let block_loc = LocatorHashes::new(vec![block_hash], Hash::zeroed());
         run_test_case(Message::GetBlocks(block_loc)).await.unwrap();
@@ -261,7 +263,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn get_data_block() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::GetData(block_inv)).await.unwrap();
     }
@@ -269,7 +271,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn get_data_tx() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         run_test_case(Message::GetData(Inv::new(vec![Block::testnet_genesis()
             .txs[0]
             .inv_hash()])))
@@ -280,7 +282,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn inv() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::Inv(block_inv)).await.unwrap();
     }
@@ -288,7 +290,7 @@ mod when_node_initiates_connection {
     #[tokio::test]
     async fn not_found() {
         // zcashd: pass
-        // zebra:  fail (disconnects)
+        // zebra:  pass
         let block_inv = Inv::new(vec![Block::testnet_genesis().inv_hash()]);
         run_test_case(Message::NotFound(block_inv)).await.unwrap();
     }

--- a/src/tests/conformance/handshake/reject_version.rs
+++ b/src/tests/conformance/handshake/reject_version.rs
@@ -16,8 +16,8 @@ async fn reusing_nonce() {
     //
     // The node rejects connections reusing its nonce (usually indicative of self-connection).
     //
-    // zebra: closes the write half of the stream, doesn't close the socket.
     // zcashd: closes the write half of the stream, doesn't close the socket.
+    // zebra: pass
 
     // Create a synthetic node, no handshake, no message filters.
     let mut synthetic_node = SyntheticNode::builder().build().await.unwrap();
@@ -54,10 +54,10 @@ async fn with_obsolete_version_numbers() {
     //
     // The node rejects connections with obsolete node versions.
     //
-    // zebra: doesn't send a reject, closes the write half of the stream, doesn't close the socket.
+    // zebra: doesn't send a reject, the connection gets dropped.
     // zcashd: sends reject before closing the write half of the stream, doesn't close the socket.
 
-    let obsolete_version_numbers: Vec<u32> = (170000..170002).collect();
+    let obsolete_version_numbers: Vec<u32> = (170000..170012).collect();
 
     // Spin up a node instance.
     let mut node = Node::new().unwrap();

--- a/src/tests/conformance/invalid_message/disconnect.rs
+++ b/src/tests/conformance/invalid_message/disconnect.rs
@@ -49,6 +49,7 @@ async fn pong_with_wrong_nonce() {
         .start()
         .await
         .unwrap();
+
     // Create SyntheticNode which lets through Ping's
     let mut synthetic_node = SyntheticNode::builder()
         .with_full_handshake()
@@ -92,7 +93,7 @@ async fn pong_with_wrong_nonce() {
 #[tokio::test]
 async fn get_data_with_mixed_types() {
     // zcashd: fail (replies with Block)
-    // zebra:  pass
+    // zebra:  fail (replies with NotFound)
     let genesis_block = Block::testnet_genesis();
     let mixed_inv = vec![genesis_block.inv_hash(), genesis_block.txs[0].inv_hash()];
     let message = Message::GetData(Inv::new(mixed_inv));
@@ -102,7 +103,7 @@ async fn get_data_with_mixed_types() {
 #[tokio::test]
 async fn inv_with_mixed_types() {
     // zcashd: fail (message ignored)
-    // zebra:  pass
+    // zebra:  fail (message ignored)
 
     // Inv with mixed inventory (using non-genesis block since all node's "should" have genesis already,
     // which makes advertising it non-sensical).
@@ -169,6 +170,7 @@ async fn run_test_case_bytes(bytes: Vec<u8>) -> io::Result<()> {
     node.initial_action(Action::WaitForConnection)
         .start()
         .await?;
+
     let mut synthetic_node = SyntheticNode::builder()
         .with_full_handshake()
         .with_all_auto_reply()

--- a/src/tests/conformance/invalid_message/reject.rs
+++ b/src/tests/conformance/invalid_message/reject.rs
@@ -44,8 +44,10 @@ async fn verack_post_handshake() {
 
 #[tokio::test]
 async fn mixed_inventory() {
+    // TODO: is this the desired behaviour, https://github.com/ZcashFoundation/zebra/issues/2107
+    // might suggest it is.
     // zcashd: fail (ignored)
-    // zebra:  fail (connection terminated)
+    // zebra:  fail (ignored)
     let genesis_block = Block::testnet_genesis();
     let mixed_inv = vec![genesis_block.inv_hash(), genesis_block.txs[0].inv_hash()];
 
@@ -57,7 +59,7 @@ async fn mixed_inventory() {
 #[tokio::test]
 async fn multi_block_inventory() {
     // zcashd: fail (ignored)
-    // zebra:  fail (connection terminated)
+    // zebra:  fail (ignored)
     let multi_block_inv = vec![
         Block::testnet_genesis().inv_hash(),
         Block::testnet_1().inv_hash(),
@@ -72,7 +74,7 @@ async fn multi_block_inventory() {
 #[tokio::test]
 async fn bloom_filter_add() {
     // zcashd: fail (ccode: Malformed)
-    // zebra:  fail (connection terminated)
+    // zebra:  fail (ignored)
     run_test_case(Message::FilterAdd(FilterAdd::default()), CCode::Obsolete)
         .await
         .unwrap();
@@ -81,7 +83,7 @@ async fn bloom_filter_add() {
 #[tokio::test]
 async fn bloom_filter_load() {
     // zcashd: fail (ccode: Malformed)
-    // zebra:  fail (connection terminated)
+    // zebra:  fail (ignored)
     run_test_case(Message::FilterLoad(FilterLoad::default()), CCode::Obsolete)
         .await
         .unwrap();
@@ -90,7 +92,7 @@ async fn bloom_filter_load() {
 #[tokio::test]
 async fn bloom_filter_clear() {
     // zcashd: fail (ignored)
-    // zebra:  fail (connection terminated)
+    // zebra:  fail (ignored)
     run_test_case(Message::FilterClear, CCode::Obsolete)
         .await
         .unwrap();

--- a/src/tests/conformance/query/basic_query.rs
+++ b/src/tests/conformance/query/basic_query.rs
@@ -84,7 +84,7 @@ mod node_is_seeded_with_blocks {
     }
 
     #[tokio::test]
-    #[should_panic]
+    // #[should_panic]
     // This test should currently fail, since we have no way of seeding the Mempool of the node.
     async fn get_data_tx() {
         // zcashd: fail (NotFound), this is expected as we cannot seed the mempool of the node.
@@ -160,7 +160,7 @@ mod node_is_not_seeded_with_blocks {
     #[tokio::test]
     async fn get_addr() {
         // zcashd: fail (query ignored)
-        // zebra:  pass
+        // zebra:  fail (query ignored, nil response internally)
         let reply = run_test_case(Message::GetAddr).await.unwrap();
         assert_matches!(reply, Message::Addr(..));
     }
@@ -188,7 +188,8 @@ mod node_is_not_seeded_with_blocks {
     #[tokio::test]
     async fn get_data_block() {
         // zcashd: fail (query ignored)
-        // zebra:  fail (query ignored)
+        // zebra:  fail (query ignored), pass when timeout is used to account for node startup (10s
+        // is usually enough).
         let inv = Inv::new(vec![Block::testnet_2().inv_hash()]);
         let query = Message::GetData(inv.clone());
         let expected = Message::NotFound(inv);
@@ -199,7 +200,8 @@ mod node_is_not_seeded_with_blocks {
     #[tokio::test]
     async fn get_data_tx() {
         // zcashd: pass
-        // zebra:  fail (query ignored)
+        // zebra:  fail (query ignored), sometimes pass (flaky), reliably passes when timeout is
+        // used to account for node startup (10s is usually enough).
         let inv = Inv::new(vec![Block::testnet_genesis().txs[0].inv_hash()]);
         let query = Message::GetData(inv.clone());
         let expected = Message::NotFound(inv);

--- a/src/tests/conformance/query/basic_query.rs
+++ b/src/tests/conformance/query/basic_query.rs
@@ -84,7 +84,6 @@ mod node_is_seeded_with_blocks {
     }
 
     #[tokio::test]
-    // #[should_panic]
     // This test should currently fail, since we have no way of seeding the Mempool of the node.
     async fn get_data_tx() {
         // zcashd: fail (NotFound), this is expected as we cannot seed the mempool of the node.


### PR DESCRIPTION
Updates pass/fail for conformance tests against Zebra. Investigations required:
- changes to the peering protocol.
- block/mempool state seeding? 
- comparison with Zcashd behaviour and spec adjustments based on the canonical impl.