### PR TITLE
Timeout constant unification for conformance tests

### DIFF
--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -11,13 +11,14 @@ use crate::{
     tools::{
         message_filter::{Filter, MessageFilter},
         synthetic_node::SyntheticNode,
+        TIMEOUT,
     },
     wait_until,
 };
 
 use std::process::{Child, Command};
 
-use std::{fs, io, net::SocketAddr, process::Stdio, time::Duration};
+use std::{fs, io, net::SocketAddr, process::Stdio};
 
 /// Actions to prepare node state on start.
 pub enum Action {
@@ -164,8 +165,6 @@ impl Node {
     }
 
     async fn perform_initial_action(&self, mut synthetic_node: SyntheticNode) -> io::Result<()> {
-        const TIMEOUT: Duration = Duration::from_secs(10);
-
         match self.config.initial_action {
             Action::None => {}
             Action::WaitForConnection => {

--- a/src/setup/node.rs
+++ b/src/setup/node.rs
@@ -11,7 +11,7 @@ use crate::{
     tools::{
         message_filter::{Filter, MessageFilter},
         synthetic_node::SyntheticNode,
-        TIMEOUT,
+        LONG_TIMEOUT,
     },
     wait_until,
 };
@@ -169,7 +169,7 @@ impl Node {
             Action::None => {}
             Action::WaitForConnection => {
                 // The synthetic node will accept the connection and handshake by itself.
-                wait_until!(TIMEOUT, synthetic_node.num_connected() == 1);
+                wait_until!(LONG_TIMEOUT, synthetic_node.num_connected() == 1);
             }
             Action::SeedWithTestnetBlocks(_) if self.meta.kind == NodeKind::Zebra => {
                 unimplemented!("zebra doesn't support block seeding");
@@ -186,7 +186,7 @@ impl Node {
                     .collect::<Vec<_>>();
 
                 // respond to GetHeaders(Block[0])
-                let source = match synthetic_node.recv_message_timeout(TIMEOUT).await? {
+                let source = match synthetic_node.recv_message_timeout(LONG_TIMEOUT).await? {
                     (source, Message::GetHeaders(locations)) => {
                         // The request should be from the genesis hash onwards,
                         // i.e. locator_hash = [genesis.hash], stop_hash = [0]
@@ -213,7 +213,7 @@ impl Node {
                 };
 
                 // respond to GetData(inv) for the initial blocks
-                match synthetic_node.recv_message_timeout(TIMEOUT).await? {
+                match synthetic_node.recv_message_timeout(LONG_TIMEOUT).await? {
                     (source, Message::GetData(inv)) => {
                         // The request must be for the initial blocks
                         let inv_hashes = blocks.iter().map(|block| block.inv_hash()).collect();
@@ -236,7 +236,9 @@ impl Node {
                 }
 
                 // Check that the node has received and processed all previous messages.
-                synthetic_node.ping_pong_timeout(source, TIMEOUT).await?;
+                synthetic_node
+                    .ping_pong_timeout(source, LONG_TIMEOUT)
+                    .await?;
             }
         }
 

--- a/src/tests/conformance/handshake/complete_handshake.rs
+++ b/src/tests/conformance/handshake/complete_handshake.rs
@@ -1,6 +1,6 @@
 use crate::{
     setup::node::{Action, Node},
-    tools::{synthetic_node::SyntheticNode, TIMEOUT},
+    tools::{synthetic_node::SyntheticNode, LONG_TIMEOUT},
     wait_until,
 };
 
@@ -53,7 +53,7 @@ async fn when_node_initiates_connection() {
 
     // Check the connection has been established (this is only set post-handshake). We can't check
     // for the addr as nodes use ephemeral addresses when initiating connections.
-    wait_until!(TIMEOUT, synthetic_node.num_connected() == 1);
+    wait_until!(LONG_TIMEOUT, synthetic_node.num_connected() == 1);
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;

--- a/src/tests/conformance/handshake/complete_handshake.rs
+++ b/src/tests/conformance/handshake/complete_handshake.rs
@@ -1,8 +1,6 @@
-use std::time::Duration;
-
 use crate::{
     setup::node::{Action, Node},
-    tools::synthetic_node::SyntheticNode,
+    tools::{synthetic_node::SyntheticNode, TIMEOUT},
     wait_until,
 };
 
@@ -55,7 +53,7 @@ async fn when_node_initiates_connection() {
 
     // Check the connection has been established (this is only set post-handshake). We can't check
     // for the addr as nodes use ephemeral addresses when initiating connections.
-    wait_until!(Duration::from_secs(5), synthetic_node.num_connected() == 1);
+    wait_until!(TIMEOUT, synthetic_node.num_connected() == 1);
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_verack.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_verack.rs
@@ -13,7 +13,7 @@ use crate::{
         },
     },
     setup::node::{Action, Node},
-    tools::{synthetic_node::SyntheticNode, RECV_TIMEOUT, TIMEOUT},
+    tools::{synthetic_node::SyntheticNode, LONG_TIMEOUT, RECV_TIMEOUT},
 };
 
 mod when_node_receives_connection {
@@ -272,7 +272,8 @@ mod when_node_initiates_connection {
         // Wait for the node to establish the connection.
         // This will result in a connection in which the Version's have
         // already been exchanged.
-        let node_addr = tokio::time::timeout(TIMEOUT, synthetic_node.wait_for_connection()).await?;
+        let node_addr =
+            tokio::time::timeout(LONG_TIMEOUT, synthetic_node.wait_for_connection()).await?;
 
         // Send a non-version message.
         synthetic_node.send_direct_message(node_addr, message)?;

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_verack.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_verack.rs
@@ -2,7 +2,7 @@
 //!
 //! The node ignores non-`Verack` message as a response to initial `Verack` it sent.
 
-use std::{io, time::Duration};
+use std::io;
 
 use crate::{
     protocol::{
@@ -13,11 +13,8 @@ use crate::{
         },
     },
     setup::node::{Action, Node},
-    tools::synthetic_node::SyntheticNode,
+    tools::{synthetic_node::SyntheticNode, RECV_TIMEOUT, TIMEOUT},
 };
-
-const RECV_TIMEOUT: Duration = Duration::from_millis(100);
-const CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 mod when_node_receives_connection {
     //! Contains test cases which cover ZG-CONFORMANCE-005.
@@ -275,8 +272,7 @@ mod when_node_initiates_connection {
         // Wait for the node to establish the connection.
         // This will result in a connection in which the Version's have
         // already been exchanged.
-        let node_addr =
-            tokio::time::timeout(CONNECTION_TIMEOUT, synthetic_node.wait_for_connection()).await?;
+        let node_addr = tokio::time::timeout(TIMEOUT, synthetic_node.wait_for_connection()).await?;
 
         // Send a non-version message.
         synthetic_node.send_direct_message(node_addr, message)?;

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
@@ -11,7 +11,7 @@ use crate::{
         },
     },
     setup::node::{Action, Node},
-    tools::{synthetic_node::SyntheticNode, RECV_TIMEOUT, TIMEOUT},
+    tools::{synthetic_node::SyntheticNode, LONG_TIMEOUT, RECV_TIMEOUT},
 };
 
 use std::io;
@@ -305,7 +305,8 @@ mod when_node_initiates_connection {
             .await?;
 
         // Wait for the node to establish the connection.
-        let node_addr = tokio::time::timeout(TIMEOUT, synthetic_node.wait_for_connection()).await?;
+        let node_addr =
+            tokio::time::timeout(LONG_TIMEOUT, synthetic_node.wait_for_connection()).await?;
 
         // Send a non-version message.
         synthetic_node.send_direct_message(node_addr, message)?;

--- a/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
+++ b/src/tests/conformance/handshake/ignore_message_inplace_of_version.rs
@@ -11,13 +11,10 @@ use crate::{
         },
     },
     setup::node::{Action, Node},
-    tools::synthetic_node::SyntheticNode,
+    tools::{synthetic_node::SyntheticNode, RECV_TIMEOUT, TIMEOUT},
 };
 
-use std::{io, time::Duration};
-
-const RECV_TIMEOUT: Duration = Duration::from_millis(100);
-const CONNECTION_TIMEOUT: Duration = Duration::from_secs(5);
+use std::io;
 
 mod when_node_receives_connection {
     //! Contains test cases which cover ZG-CONFORMANCE-003.
@@ -308,8 +305,7 @@ mod when_node_initiates_connection {
             .await?;
 
         // Wait for the node to establish the connection.
-        let node_addr =
-            tokio::time::timeout(CONNECTION_TIMEOUT, synthetic_node.wait_for_connection()).await?;
+        let node_addr = tokio::time::timeout(TIMEOUT, synthetic_node.wait_for_connection()).await?;
 
         // Send a non-version message.
         synthetic_node.send_direct_message(node_addr, message)?;

--- a/src/tests/conformance/handshake/reject_version.rs
+++ b/src/tests/conformance/handshake/reject_version.rs
@@ -4,7 +4,7 @@ use crate::{
         payload::{reject::CCode, Version},
     },
     setup::node::{Action, Node},
-    tools::{synthetic_node::SyntheticNode, TIMEOUT},
+    tools::{synthetic_node::SyntheticNode, LONG_TIMEOUT},
     wait_until,
 };
 
@@ -30,7 +30,10 @@ async fn reusing_nonce() {
         .unwrap();
 
     // Receive a Version.
-    let (source, version) = synthetic_node.recv_message_timeout(TIMEOUT).await.unwrap();
+    let (source, version) = synthetic_node
+        .recv_message_timeout(LONG_TIMEOUT)
+        .await
+        .unwrap();
     let nonce = assert_matches!(version, Message::Version(version) => version.nonce);
 
     // Send a Version.
@@ -41,7 +44,7 @@ async fn reusing_nonce() {
         .unwrap();
 
     // Assert on disconnect.
-    wait_until!(TIMEOUT, synthetic_node.num_connected() == 0);
+    wait_until!(LONG_TIMEOUT, synthetic_node.num_connected() == 0);
 
     // Gracefully shut down the nodes.
     synthetic_node.shut_down().await;
@@ -86,11 +89,14 @@ async fn with_obsolete_version_numbers() {
             .unwrap();
 
         // Expect a reject message.
-        let (_, reject) = synthetic_node.recv_message_timeout(TIMEOUT).await.unwrap();
+        let (_, reject) = synthetic_node
+            .recv_message_timeout(LONG_TIMEOUT)
+            .await
+            .unwrap();
         assert_matches!(reject, Message::Reject(reject) if reject.ccode == CCode::Obsolete);
 
         // Expect the connection to be dropped.
-        wait_until!(TIMEOUT, synthetic_node.num_connected() == 0);
+        wait_until!(LONG_TIMEOUT, synthetic_node.num_connected() == 0);
 
         // Gracefully shut down the synthetic node.
         synthetic_node.shut_down().await;

--- a/src/tests/conformance/invalid_message/disconnect.rs
+++ b/src/tests/conformance/invalid_message/disconnect.rs
@@ -18,7 +18,6 @@
 use std::{
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    time::Duration,
 };
 
 use crate::{
@@ -33,16 +32,14 @@ use crate::{
     tools::{
         message_filter::{Filter, MessageFilter},
         synthetic_node::{PingPongError, SyntheticNode},
+        RECV_TIMEOUT, TIMEOUT,
     },
 };
-
-const DC_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[tokio::test]
 async fn pong_with_wrong_nonce() {
     // zcashd: fail (message ignored)
     // zebra:  fail (message ignored)
-    const PING_TIMEOUT: Duration = Duration::from_secs(1);
 
     let mut node = Node::new().unwrap();
     node.initial_action(Action::WaitForConnection)
@@ -63,7 +60,7 @@ async fn pong_with_wrong_nonce() {
     synthetic_node.connect(node.addr()).await.unwrap();
 
     // Wait for a Ping request.
-    match synthetic_node.recv_message_timeout(PING_TIMEOUT).await {
+    match synthetic_node.recv_message_timeout(RECV_TIMEOUT).await {
         Ok((_, Message::Ping(_))) => synthetic_node
             .send_direct_message(node.addr(), Message::Pong(Nonce::default()))
             .unwrap(),
@@ -77,10 +74,7 @@ async fn pong_with_wrong_nonce() {
 
     // Use Ping-Pong to check node's response.
     // We expect a disconnect.
-    match synthetic_node
-        .ping_pong_timeout(node.addr(), DC_TIMEOUT)
-        .await
-    {
+    match synthetic_node.ping_pong_timeout(node.addr(), TIMEOUT).await {
         Err(PingPongError::ConnectionAborted) => {}
         Ok(_) => panic!("Message was ignored."),
         Err(err) => panic!("Connection was not aborted: {:?}", err),
@@ -183,10 +177,7 @@ async fn run_test_case_bytes(bytes: Vec<u8>) -> io::Result<()> {
     // Use Ping-Pong to check node's response.
     // We expect a disconnect.
     use PingPongError::*;
-    let result = match synthetic_node
-        .ping_pong_timeout(node.addr(), DC_TIMEOUT)
-        .await
-    {
+    let result = match synthetic_node.ping_pong_timeout(node.addr(), TIMEOUT).await {
         Err(ConnectionAborted) => Ok(()),
         Ok(_) => Err(io::Error::new(io::ErrorKind::Other, "Message was ignored")),
         Err(Unexpected(msg)) => Err(io::Error::new(

--- a/src/tests/conformance/invalid_message/disconnect.rs
+++ b/src/tests/conformance/invalid_message/disconnect.rs
@@ -32,7 +32,7 @@ use crate::{
     tools::{
         message_filter::{Filter, MessageFilter},
         synthetic_node::{PingPongError, SyntheticNode},
-        RECV_TIMEOUT, TIMEOUT,
+        LONG_TIMEOUT, RECV_TIMEOUT,
     },
 };
 
@@ -74,7 +74,10 @@ async fn pong_with_wrong_nonce() {
 
     // Use Ping-Pong to check node's response.
     // We expect a disconnect.
-    match synthetic_node.ping_pong_timeout(node.addr(), TIMEOUT).await {
+    match synthetic_node
+        .ping_pong_timeout(node.addr(), LONG_TIMEOUT)
+        .await
+    {
         Err(PingPongError::ConnectionAborted) => {}
         Ok(_) => panic!("Message was ignored."),
         Err(err) => panic!("Connection was not aborted: {:?}", err),
@@ -177,7 +180,10 @@ async fn run_test_case_bytes(bytes: Vec<u8>) -> io::Result<()> {
     // Use Ping-Pong to check node's response.
     // We expect a disconnect.
     use PingPongError::*;
-    let result = match synthetic_node.ping_pong_timeout(node.addr(), TIMEOUT).await {
+    let result = match synthetic_node
+        .ping_pong_timeout(node.addr(), LONG_TIMEOUT)
+        .await
+    {
         Err(ConnectionAborted) => Ok(()),
         Ok(_) => Err(io::Error::new(io::ErrorKind::Other, "Message was ignored")),
         Err(Unexpected(msg)) => Err(io::Error::new(

--- a/src/tests/conformance/invalid_message/reject.rs
+++ b/src/tests/conformance/invalid_message/reject.rs
@@ -10,7 +10,7 @@
 //!  Bloom filter load       - Obsolete
 //!  Bloom filter clear      - Obsolete
 
-use std::{io, time::Duration};
+use std::io;
 
 use crate::{
     protocol::{
@@ -18,7 +18,10 @@ use crate::{
         payload::{block::Block, reject::CCode, FilterAdd, FilterLoad, Inv, Version},
     },
     setup::node::{Action, Node},
-    tools::synthetic_node::{PingPongError, SyntheticNode},
+    tools::{
+        synthetic_node::{PingPongError, SyntheticNode},
+        RECV_TIMEOUT,
+    },
 };
 
 #[tokio::test]
@@ -99,7 +102,6 @@ async fn bloom_filter_clear() {
 }
 
 async fn run_test_case(message: Message, expected_code: CCode) -> io::Result<()> {
-    const RECV_TIMEOUT: Duration = Duration::from_secs(1);
     // Setup a fully handshaken connection between a node and synthetic node.
     let mut node = Node::new()?;
     node.initial_action(Action::WaitForConnection)

--- a/src/tests/conformance/peering.rs
+++ b/src/tests/conformance/peering.rs
@@ -7,7 +7,7 @@ use crate::{
     tools::{
         message_filter::{Filter, MessageFilter},
         synthetic_node::SyntheticNode,
-        TIMEOUT,
+        LONG_TIMEOUT,
     },
     wait_until,
 };
@@ -92,7 +92,7 @@ async fn eagerly_crawls_network_for_peers() {
 
     // Expect the synthetic nodes to get a connection request from the node.
     for node in synthetic_nodes {
-        wait_until!(TIMEOUT, node.num_connected() == 1);
+        wait_until!(LONG_TIMEOUT, node.num_connected() == 1);
 
         node.shut_down().await;
     }
@@ -162,7 +162,10 @@ async fn correctly_lists_peers() {
             .send_direct_message(node.addr(), Message::GetAddr)
             .unwrap();
 
-        let (_, addr) = synthetic_node.recv_message_timeout(TIMEOUT).await.unwrap();
+        let (_, addr) = synthetic_node
+            .recv_message_timeout(LONG_TIMEOUT)
+            .await
+            .unwrap();
         let addrs = assert_matches!(addr, Message::Addr(addrs) => addrs);
 
         // Check that ephemeral connections were not gossiped.

--- a/src/tests/conformance/query/basic_query.rs
+++ b/src/tests/conformance/query/basic_query.rs
@@ -26,12 +26,13 @@ use crate::{
         },
     },
     setup::node::{Action, Node},
-    tools::synthetic_node::{PingPongError, SyntheticNode},
+    tools::{
+        synthetic_node::{PingPongError, SyntheticNode},
+        RECV_TIMEOUT,
+    },
 };
 use assert_matches::assert_matches;
-use std::{io, time::Duration};
-
-const RECV_TIMEOUT: Duration = Duration::from_millis(100);
+use std::io;
 
 mod node_is_seeded_with_blocks {
     use super::*;

--- a/src/tests/conformance/query/mod.rs
+++ b/src/tests/conformance/query/mod.rs
@@ -1,4 +1,4 @@
-use std::{io, time::Duration};
+use std::io;
 
 use crate::{
     protocol::{
@@ -6,7 +6,7 @@ use crate::{
         payload::{block::Block, Nonce},
     },
     setup::node::{Action, Node},
-    tools::synthetic_node::SyntheticNode,
+    tools::{synthetic_node::SyntheticNode, RECV_TIMEOUT},
 };
 
 mod basic_query;
@@ -49,7 +49,6 @@ async fn run_test_query(query: Message) -> io::Result<Vec<Message>> {
     synthetic_node.send_direct_message(node.addr(), Message::Ping(nonce))?;
 
     // Receive messages until we receive the matching Pong, or we timeout.
-    const RECV_TIMEOUT: Duration = Duration::from_millis(100);
     let mut messages = Vec::new();
     loop {
         match synthetic_node.recv_message_timeout(RECV_TIMEOUT).await? {

--- a/src/tests/conformance/unsolicited_response.rs
+++ b/src/tests/conformance/unsolicited_response.rs
@@ -4,7 +4,7 @@
 //!
 //!  Reject, NotFound, Pong, Tx, Block, Header, Addr
 
-use std::{io, time::Duration};
+use std::io;
 
 use crate::{
     protocol::{
@@ -15,7 +15,7 @@ use crate::{
         },
     },
     setup::node::{Action, Node},
-    tools::synthetic_node::SyntheticNode,
+    tools::{synthetic_node::SyntheticNode, RECV_TIMEOUT},
 };
 
 #[tokio::test]
@@ -89,7 +89,7 @@ async fn run_test_case(message: Message) -> io::Result<()> {
 
     // A response to ping would indicate the previous message was ignored.
     let result = synthetic_node
-        .ping_pong_timeout(node.addr(), Duration::from_secs(1))
+        .ping_pong_timeout(node.addr(), RECV_TIMEOUT)
         .await;
 
     // Gracefully shut down the nodes.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 
 /// Default timeout for connection operations in seconds.
 /// TODO: move to config file.
-pub const TIMEOUT: Duration = Duration::from_secs(10);
+pub const LONG_TIMEOUT: Duration = Duration::from_secs(10);
 /// Default timeout for response-specific reads in seconds.
 pub const RECV_TIMEOUT: Duration = Duration::from_millis(100);
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -8,7 +8,9 @@ pub mod synthetic_node;
 use std::time::Duration;
 
 /// Default timeout for connection reads in seconds.
+/// TODO: move to config file.
 pub const TIMEOUT: Duration = Duration::from_secs(10);
+pub const RECV_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Waits until an expression is true or times out.
 ///

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,9 +7,10 @@ pub mod synthetic_node;
 
 use std::time::Duration;
 
-/// Default timeout for connection reads in seconds.
+/// Default timeout for connection operations in seconds.
 /// TODO: move to config file.
 pub const TIMEOUT: Duration = Duration::from_secs(10);
+/// Default timeout for response-specific reads in seconds.
 pub const RECV_TIMEOUT: Duration = Duration::from_millis(100);
 
 /// Waits until an expression is true or times out.


### PR DESCRIPTION
This starts unifying the various timeout constants in the context of conformance tests. In future the same should be done for the performance and resistance tests. They should likely also be made configurable in Ziggurat's configuration file.