### PR TITLE
Move crawler to bin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,15 @@ default-features = false
 version = "0.3"
 features = [ "env-filter", "fmt" ]
 
+[dependencies.clap]
+version = "3.2.7"
+features = [ "derive" ]
+optional = true
+
+[features]
+crawler = ["clap"]
+
+[[bin]]
+name = "crawler"
+path = "src/tools/crawler/main.rs"
+required-features = ["crawler"]

--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -1,0 +1,126 @@
+use std::time::{Duration, Instant};
+
+use clap::Parser;
+use pea2pea::{
+    protocols::{Handshake, Reading, Writing},
+    Pea2Pea,
+};
+use rand::prelude::IteratorRandom;
+use tokio::time::sleep;
+use tracing::info;
+use tracing_subscriber::filter::{EnvFilter, LevelFilter};
+use ziggurat::{protocol::message::Message, wait_until};
+
+use crate::{
+    protocol::{Crawler, MAIN_LOOP_INTERVAL, NUM_CONN_ATTEMPTS_PERIODIC},
+    network::KnownNode,
+    summary::NetworkSummary,
+};
+
+mod protocol;
+mod network;
+mod summary;
+
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    #[clap(short, long, value_parser, min_values = 1)]
+    seed_addrs: Vec<String>,
+    #[clap(short, long, value_parser, default_value_t = MAIN_LOOP_INTERVAL)]
+    crawl_interval: u64,
+    #[clap(short, long, value_parser, default_value = "testnet")]
+    network: String,
+}
+
+fn start_logger(default_level: LevelFilter) {
+    let filter = match EnvFilter::try_from_default_env() {
+        Ok(filter) => filter
+            .add_directive("tokio_util=off".parse().unwrap())
+            .add_directive("mio=off".parse().unwrap()),
+        _ => EnvFilter::default()
+            .add_directive(default_level.into())
+            .add_directive("tokio_util=off".parse().unwrap())
+            .add_directive("mio=off".parse().unwrap()),
+    };
+
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .init();
+}
+
+#[tokio::main]
+async fn main() {
+    start_logger(LevelFilter::TRACE);
+    let args = Args::parse();
+
+    // Create the crawler with the given listener address.
+    let crawler = Crawler::new().await;
+
+    crawler.enable_handshake().await;
+    crawler.enable_reading().await;
+    crawler.enable_writing().await;
+
+    for addr in args.seed_addrs {
+        let crawler_clone = crawler.clone();
+        tokio::spawn(async move {
+            let addr = addr.parse().unwrap();
+            crawler_clone
+                .known_network
+                .nodes
+                .write()
+                .insert(addr, KnownNode::default());
+
+            if crawler_clone.connect(addr).await.is_ok() {
+                sleep(Duration::from_secs(1)).await;
+                let _ = crawler_clone.send_direct_message(addr, Message::GetAddr);
+            }
+        });
+    }
+
+    // Wait for the connection to be complete.
+    wait_until!(Duration::from_secs(3), crawler.node().num_connected() >= 1);
+
+    sleep(Duration::from_secs(1)).await;
+
+    // Capture the start time of the crawler.
+    let crawler_start_time = Instant::now();
+
+    tokio::spawn(async move {
+        loop {
+            crawler.known_network.update_nodes();
+
+            info!(parent: crawler.node().span(), "asking peers for their peers (connected to {})", crawler.node().num_connected());
+            info!(parent: crawler.node().span(), "known addrs: {}", crawler.known_network.num_nodes());
+
+            for (addr, _) in crawler
+                .known_network
+                .nodes()
+                .into_iter()
+                .choose_multiple(&mut rand::thread_rng(), NUM_CONN_ATTEMPTS_PERIODIC)
+            {
+                if !(crawler.node().is_connected(addr) || crawler.node().is_connecting(addr)) {
+                    let crawler_clone = crawler.clone();
+                    tokio::spawn(async move {
+                        if crawler_clone.connect(addr).await.is_ok() {
+                            sleep(Duration::from_secs(1)).await;
+                            let _ = crawler_clone.send_direct_message(addr, Message::GetAddr);
+                        }
+                    });
+                }
+            }
+
+            crawler.send_broadcast(Message::GetAddr).unwrap();
+
+            // Create summary and log to file.
+            let network_summary =
+                NetworkSummary::new(crawler.known_network.nodes(), crawler_start_time);
+            network_summary.log_to_file().unwrap();
+            info!("{}", network_summary);
+
+            sleep(Duration::from_secs(args.crawl_interval)).await;
+        }
+    });
+
+    std::future::pending::<()>().await;
+}

--- a/src/tools/crawler/mod.rs
+++ b/src/tools/crawler/mod.rs
@@ -1,5 +1,0 @@
-//! Network crawler.
-
-pub mod bin;
-pub mod network;
-pub mod summary;

--- a/src/tools/crawler/network.rs
+++ b/src/tools/crawler/network.rs
@@ -7,8 +7,7 @@ use std::{
 };
 
 use parking_lot::RwLock;
-
-use crate::protocol::payload::{ProtocolVersion, VarStr};
+use ziggurat::protocol::payload::{ProtocolVersion, VarStr};
 
 /// A node encountered in the network or obtained from one of the peers.
 #[derive(Debug, Default, Clone)]
@@ -103,6 +102,7 @@ impl KnownNetwork {
     }
 
     /// Returns the number of known connections.
+    #[allow(dead_code)]
     pub fn num_connections(&self) -> usize {
         self.connections.read().len()
     }

--- a/src/tools/crawler/summary.rs
+++ b/src/tools/crawler/summary.rs
@@ -1,9 +1,10 @@
 use core::fmt;
 use std::{
+    cmp,
     collections::HashMap,
+    fs,
     net::SocketAddr,
-    time::{Instant, Duration},
-    cmp, fs,
+    time::{Duration, Instant},
 };
 
 use super::network::KnownNode;
@@ -21,10 +22,14 @@ pub struct NetworkSummary {
 
 impl NetworkSummary {
     /// Constructs a new NetworkSummary from given nodes.
-    pub fn new(nodes: HashMap<SocketAddr, KnownNode>, crawler_start_time: Instant) -> NetworkSummary {
+    pub fn new(
+        nodes: HashMap<SocketAddr, KnownNode>,
+        crawler_start_time: Instant,
+    ) -> NetworkSummary {
         let num_known_nodes = nodes.len();
 
-        let good_nodes: HashMap<_, _> = nodes.clone()
+        let good_nodes: HashMap<_, _> = nodes
+            .clone()
             .into_iter()
             .filter(|(_, node)| node.last_connected.is_some())
             .collect();
@@ -36,8 +41,14 @@ impl NetworkSummary {
 
         for (_, node) in nodes {
             if let Some(_) = node.protocol_version {
-                protocol_versions.entry(node.protocol_version.unwrap().0).and_modify(|count| *count += 1).or_insert(1);
-                user_agents.entry(node.user_agent.unwrap().0).and_modify(|count| *count += 1).or_insert(1);
+                protocol_versions
+                    .entry(node.protocol_version.unwrap().0)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
+                user_agents
+                    .entry(node.user_agent.unwrap().0)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
             }
         }
 
@@ -61,7 +72,10 @@ impl NetworkSummary {
 
 impl fmt::Display for NetworkSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn print_hashmap<T: fmt::Display>(f: &mut fmt::Formatter<'_>, counts :&HashMap<T, usize>) -> fmt::Result {
+        fn print_hashmap<T: fmt::Display>(
+            f: &mut fmt::Formatter<'_>,
+            counts: &HashMap<T, usize>,
+        ) -> fmt::Result {
             let mut vec: Vec<(&T, &usize)> = counts.iter().collect();
             vec.sort_by_key(|(_, count)| cmp::Reverse(*count));
 
@@ -81,7 +95,11 @@ impl fmt::Display for NetworkSummary {
         writeln!(f, "\nUser agents:")?;
         print_hashmap(f, &self.user_agents)?;
 
-        writeln!(f, "\nCrawler ran for a total of {} minutes", self.crawler_runtime.as_secs() / 60)?;
+        writeln!(
+            f,
+            "\nCrawler ran for a total of {} minutes",
+            self.crawler_runtime.as_secs() / 60
+        )?;
 
         Ok(())
     }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,6 +1,5 @@
 //! Utilities for network testing.
 
-pub mod crawler;
 pub mod fuzzing;
 pub mod message_filter;
 pub mod metrics;


### PR DESCRIPTION
Moves crawler to a new binary under `/tools/crawler/`. Also introduces basic integration with `clap` for command-line argument parsing and some minor refactoring.