### PR TITLE
Magic header tweak

### DIFF
--- a/src/protocol/message/constants.rs
+++ b/src/protocol/message/constants.rs
@@ -16,7 +16,9 @@ pub const MAGIC_MAINNET: [u8; 4] = [0x24, 0xe9, 0x27, 0x64];
 
 #[cfg(test)]
 pub const MAGIC: [u8; 4] = MAGIC_TESTNET;
-#[cfg(not(test))]
+#[cfg(all(not(test), not(feature = "crawler")))]
+pub const MAGIC: [u8; 4] = MAGIC_MAINNET;
+#[cfg(feature = "crawler")]
 pub const MAGIC: [u8; 4] = MAGIC_MAINNET;
 
 // Message command bytes.

--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -28,8 +28,9 @@ struct Args {
     seed_addrs: Vec<String>,
     #[clap(short, long, value_parser, default_value_t = MAIN_LOOP_INTERVAL)]
     crawl_interval: u64,
-    #[clap(short, long, value_parser, default_value = "testnet")]
-    network: String,
+    // TODO
+    // #[clap(short, long, value_parser, default_value = "testnet")]
+    // network: String,
 }
 
 fn start_logger(default_level: LevelFilter) {


### PR DESCRIPTION
Temporarily removes `network` argument from crawler and tweaks magic headers.