### PR TITLE
Fix for crawler connection check

### DIFF
--- a/src/tools/crawler/network.rs
+++ b/src/tools/crawler/network.rs
@@ -85,10 +85,14 @@ pub struct KnownNetwork {
 impl KnownNetwork {
     /// Extends the list of known nodes.
     pub fn add_addrs(&self, source: SocketAddr, listening_addrs: &[SocketAddr]) {
-        let connections = &mut self.connections.write();
-        for addr in listening_addrs {
-            connections.insert(KnownConnection::new(source, *addr));
+        {
+            let connections = &mut self.connections.write();
+            for addr in listening_addrs {
+                connections.insert(KnownConnection::new(source, *addr));
+            }
         }
+
+        self.update_nodes();
     }
 
     /// Returns a snapshot of the known connections.

--- a/src/tools/crawler/protocol.rs
+++ b/src/tools/crawler/protocol.rs
@@ -90,6 +90,7 @@ impl Crawler {
             if self.node().num_connected() + self.node().num_connecting() >= MAX_CONCURRENT_CONNECTIONS {
                 return false;
             }
+
             // Ensure that there are no active connections with the given addr.
             if self.node().is_connected(addr) || self.node().is_connecting(addr) {
                 return false;


### PR DESCRIPTION
Fix for `should_connect` method, `add_addrs` now updates nodes. Introduces `MAX_CONCURRENT_CONNECTIONS` as well.