### PR TITLE
Summary tweaking

### DIFF
--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use clap::Parser;
 use pea2pea::{
@@ -84,13 +84,8 @@ async fn main() {
 
     sleep(Duration::from_secs(1)).await;
 
-    // Capture the start time of the crawler.
-    let crawler_start_time = Instant::now();
-
     tokio::spawn(async move {
         loop {
-            crawler.known_network.update_nodes();
-
             info!(parent: crawler.node().span(), "asking peers for their peers (connected to {})", crawler.node().num_connected());
             info!(parent: crawler.node().span(), "known addrs: {}", crawler.known_network.num_nodes());
 
@@ -115,14 +110,10 @@ async fn main() {
 
             if crawler.known_network.num_connections() > 0 {
                 // Create a summary and log it to a file.
-                let network_summary = NetworkSummary::new(
-                    crawler.known_network.nodes(),
-                    crawler.known_network.connections(),
-                    crawler_start_time,
-                );
+                let network_summary = NetworkSummary::new(&crawler);
 
-                network_summary.log_to_file().unwrap();
                 info!("{}", network_summary);
+                network_summary.log_to_file().unwrap();
             }
 
             sleep(Duration::from_secs(args.crawl_interval)).await;

--- a/src/tools/crawler/protocol.rs
+++ b/src/tools/crawler/protocol.rs
@@ -26,7 +26,7 @@ use super::network::KnownNetwork;
 pub const NUM_CONN_ATTEMPTS_ON_PEERLIST: usize = 100;
 pub const NUM_CONN_ATTEMPTS_PERIODIC: usize = 100;
 pub const MAX_CONCURRENT_CONNECTIONS: u16 = 1000;
-pub const MAIN_LOOP_INTERVAL: u64 = 60;
+pub const MAIN_LOOP_INTERVAL: u64 = 15;
 pub const RECONNECT_INTERVAL: u64 = 5 * 60;
 
 /// Represents the crawler together with network metrics it has collected.
@@ -34,6 +34,7 @@ pub const RECONNECT_INTERVAL: u64 = 5 * 60;
 pub struct Crawler {
     node: Pea2PeaNode,
     pub known_network: Arc<KnownNetwork>,
+    pub start_time: Instant,
 }
 
 impl Pea2Pea for Crawler {
@@ -55,6 +56,7 @@ impl Crawler {
         Self {
             node: Pea2PeaNode::new(Some(config)).await.unwrap(),
             known_network: Default::default(),
+            start_time: Instant::now(),
         }
     }
 


### PR DESCRIPTION
`NetworkSummary` now takes a reference to Crawler instead and has a new field for number of nodes that identifies themselves with a `Version`.