### PR TITLE
Only send `GetAddr` request once to seed nodes initially

### DIFF
--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -7,7 +7,7 @@ use pea2pea::{
 };
 use rand::prelude::IteratorRandom;
 use tokio::time::sleep;
-use tracing::info;
+use tracing::{error, info};
 use tracing_subscriber::filter::{EnvFilter, LevelFilter};
 use ziggurat::{protocol::message::Message, wait_until};
 
@@ -116,7 +116,9 @@ async fn main() {
                 let network_summary = network_metrics.request_summary(&crawler);
 
                 info!("{}", network_summary);
-                network_summary.log_to_file().unwrap();
+                if let Err(e) = network_summary.log_to_file() {
+                    error!(parent: crawler.node().span(), "Couldn't write summary to file: {}", e);
+                }
             }
 
             sleep(Duration::from_secs(args.crawl_interval)).await;

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -132,7 +132,7 @@ impl fmt::Display for NetworkSummary {
         writeln!(f, "Managed to connect to {} node(s)", self.num_good_nodes)?;
         writeln!(
             f,
-            "{} identifiend themselves with a Version",
+            "{} identified themselves with a Version",
             self.num_versions
         )?;
         writeln!(

--- a/src/tools/crawler/protocol.rs
+++ b/src/tools/crawler/protocol.rs
@@ -1,16 +1,10 @@
-use std::{
-    io,
-    net::SocketAddr,
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::{io, net::SocketAddr, sync::Arc, time::Instant};
 
 use futures_util::SinkExt;
 use pea2pea::{
     protocols::{Handshake, Reading, Writing},
     Config, Connection, ConnectionSide, Node as Pea2PeaNode, Pea2Pea,
 };
-use tokio::time::sleep;
 use tokio_util::codec::Framed;
 use tracing::*;
 use ziggurat::{
@@ -154,26 +148,22 @@ impl Reading for Crawler {
             }
             Message::Ping(nonce) => {
                 let _ = self
-                    .send_direct_message(source, Message::Pong(nonce))
-                    .unwrap()
+                    .send_direct_message(source, Message::Pong(nonce))?
                     .await;
             }
             Message::GetAddr => {
                 let _ = self
-                    .send_direct_message(source, Message::Addr(Addr::empty()))
-                    .unwrap()
+                    .send_direct_message(source, Message::Addr(Addr::empty()))?
                     .await;
             }
             Message::GetHeaders(_) => {
                 let _ = self
-                    .send_direct_message(source, Message::Headers(Headers::empty()))
-                    .unwrap()
+                    .send_direct_message(source, Message::Headers(Headers::empty()))?
                     .await;
             }
             Message::GetData(inv) => {
                 let _ = self
-                    .send_direct_message(source, Message::NotFound(inv.clone()))
-                    .unwrap()
+                    .send_direct_message(source, Message::NotFound(inv.clone()))?
                     .await;
             }
             Message::Version(ver) => {
@@ -184,10 +174,7 @@ impl Reading for Crawler {
                     known_node.services = Some(ver.services);
                 }
 
-                let _ = self
-                    .send_direct_message(source, Message::Verack)
-                    .unwrap()
-                    .await;
+                let _ = self.send_direct_message(source, Message::Verack)?.await;
             }
             _ => {}
         }


### PR DESCRIPTION
Instead of sending requests each iteration, crawler now waits for a response and then starts the main crawling loop. This PR also improves the crawler's general error handling.