### PR TITLE
Don't panic on non-version messages in perf-tests

### DIFF
--- a/src/tests/performance/getdata_blocks.rs
+++ b/src/tests/performance/getdata_blocks.rs
@@ -145,6 +145,7 @@ async fn throughput() {
                         }
                     }
                 }
+                synth_node.shut_down().await;
             }));
         }
 


### PR DESCRIPTION
Instead of panicking when node refuses a request from `SyntheticNode`, return an error and abort the handshake. This PR also shuts down nodes after use in `ZG-PERFORMANCE-001`, so we don't clog up the max peer count.