### PR TITLE
Introduce an RPC server for the crawler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,10 +55,15 @@ version = "3.2.7"
 features = [ "derive" ]
 optional = true
 
+[dependencies.jsonrpsee]
+version = "0.15.0"
+features = [ "http-server" ]
+optional = true
+
 [features]
-crawler = ["clap"]
+crawler = [ "clap", "jsonrpsee" ]
 
 [[bin]]
 name = "crawler"
 path = "src/tools/crawler/main.rs"
-required-features = ["crawler"]
+required-features = [ "crawler" ]

--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -51,7 +51,6 @@ struct Args {
     /// The address to bind the RPC server to
     #[clap(short, long, value_parser)]
     bind_rpc: Option<String>,
-
     // TODO
     // #[clap(short, long, value_parser, default_value = "testnet")]
     // network: String,

--- a/src/tools/crawler/main.rs
+++ b/src/tools/crawler/main.rs
@@ -36,10 +36,22 @@ const SUMMARY_LOOP_INTERVAL: u64 = 60;
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
-    #[clap(short, long, value_parser, min_values = 1)]
+    /// The initial addresses to connect to
+    #[clap(short, long, value_parser, min_values = 1, required = true)]
     seed_addrs: Vec<String>,
+
+    /// The main crawling loop interval in seconds
     #[clap(short, long, value_parser, default_value_t = MAIN_LOOP_INTERVAL)]
     crawl_interval: u64,
+
+    /// If present, start an RPC server
+    #[clap(short, long, value_parser)]
+    rpc: bool,
+
+    /// The address to bind the RPC server to
+    #[clap(short, long, value_parser)]
+    bind_rpc: Option<String>,
+
     // TODO
     // #[clap(short, long, value_parser, default_value = "testnet")]
     // network: String,
@@ -73,12 +85,18 @@ async fn main() {
     let mut network_metrics = NetworkMetrics::default();
     let summary_snapshot = Arc::new(Mutex::new(NetworkSummary::default()));
 
-    // Initialize the RPC server.
-    let rpc_addr: SocketAddr = "127.0.0.1:54321".parse().unwrap();
-    let rpc_context = RpcContext::new(Arc::clone(&summary_snapshot));
-    tokio::spawn(async move {
-        initialize_rpc_server(rpc_addr, rpc_context).await;
-    });
+    if args.rpc {
+        // Initialize the RPC server if address is specified.
+        if let Some(addr) = args.bind_rpc {
+            let rpc_addr: SocketAddr = addr.parse().unwrap();
+            let rpc_context = RpcContext::new(Arc::clone(&summary_snapshot));
+            tokio::spawn(async move {
+                initialize_rpc_server(rpc_addr, rpc_context).await;
+            });
+        } else {
+            error!(parent: crawler.node().span(), "no rpc address was specified, refusing to start server");
+        }
+    }
 
     crawler.enable_handshake().await;
     crawler.enable_reading().await;
@@ -160,9 +178,12 @@ async fn main() {
                 network_metrics.update_graph(&crawler);
                 let new_summary = network_metrics.request_summary(&crawler);
 
-                info!("{}", new_summary);
-                if let Err(e) = new_summary.log_to_file() {
-                    error!(parent: crawler.node().span(), "Couldn't write summary to file: {}", e);
+                // If RPC flag is supplied, disable file logging.
+                if !args.rpc {
+                    info!("{}", new_summary);
+                    if let Err(e) = new_summary.log_to_file() {
+                        error!(parent: crawler.node().span(), "Couldn't write summary to file: {}", e);
+                    }
                 }
 
                 // Aquire lock and replace old summary snapshot with the newly generated one.

--- a/src/tools/crawler/metrics.rs
+++ b/src/tools/crawler/metrics.rs
@@ -1,6 +1,7 @@
 use core::fmt;
 use std::{cmp, collections::HashMap, fs, net::SocketAddr, time::Duration};
 
+use serde::Serialize;
 use spectre::{edge::Edge, graph::Graph};
 
 use crate::{network::LAST_SEEN_CUTOFF, Crawler};
@@ -32,6 +33,7 @@ impl NetworkMetrics {
 }
 
 #[allow(dead_code)]
+#[derive(Default, Clone, Serialize)]
 pub struct NetworkSummary {
     num_known_nodes: usize,
     num_good_nodes: usize,

--- a/src/tools/crawler/rpc.rs
+++ b/src/tools/crawler/rpc.rs
@@ -39,9 +39,11 @@ pub async fn initialize_rpc_server(rpc_addr: SocketAddr, rpc_context: RpcContext
 fn create_rpc_module(rpc_context: RpcContext) -> RpcModule<RpcContext> {
     let mut module = RpcModule::new(rpc_context);
 
-    module.register_method("getmetrics", |_, rpc_context| {
-        Ok(rpc_context.lock().clone())
-    }).unwrap();
+    module
+        .register_method("getmetrics", |_, rpc_context| {
+            Ok(rpc_context.lock().clone())
+        })
+        .unwrap();
 
     module
 }

--- a/src/tools/crawler/rpc.rs
+++ b/src/tools/crawler/rpc.rs
@@ -1,0 +1,47 @@
+use std::{net::SocketAddr, sync::Arc};
+
+use jsonrpsee::http_server::{HttpServerBuilder, RpcModule};
+use parking_lot::Mutex;
+use tracing::debug;
+
+use crate::metrics::NetworkSummary;
+
+pub struct RpcContext(Arc<Mutex<NetworkSummary>>);
+
+impl RpcContext {
+    /// Creates a new RpcContext.
+    pub fn new(known_network: Arc<Mutex<NetworkSummary>>) -> RpcContext {
+        RpcContext(known_network)
+    }
+}
+
+impl std::ops::Deref for RpcContext {
+    type Target = Mutex<NetworkSummary>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub async fn initialize_rpc_server(rpc_addr: SocketAddr, rpc_context: RpcContext) {
+    let server = HttpServerBuilder::default().build(rpc_addr).await.unwrap();
+
+    let module = create_rpc_module(rpc_context);
+
+    debug!("Starting RPC server at {:?}", server.local_addr().unwrap());
+    let _server_handle = server.start(module).unwrap();
+
+    debug!("RPC server was successfully started");
+
+    std::future::pending::<()>().await;
+}
+
+fn create_rpc_module(rpc_context: RpcContext) -> RpcModule<RpcContext> {
+    let mut module = RpcModule::new(rpc_context);
+
+    module.register_method("getmetrics", |_, rpc_context| {
+        Ok(rpc_context.lock().clone())
+    }).unwrap();
+
+    module
+}

--- a/src/tools/crawler/rpc.rs
+++ b/src/tools/crawler/rpc.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, sync::Arc};
 
-use jsonrpsee::http_server::{HttpServerBuilder, RpcModule};
+use jsonrpsee::http_server::{HttpServerBuilder, HttpServerHandle, RpcModule};
 use parking_lot::Mutex;
 use tracing::debug;
 
@@ -23,17 +23,18 @@ impl std::ops::Deref for RpcContext {
     }
 }
 
-pub async fn initialize_rpc_server(rpc_addr: SocketAddr, rpc_context: RpcContext) {
+pub async fn initialize_rpc_server(
+    rpc_addr: SocketAddr,
+    rpc_context: RpcContext,
+) -> HttpServerHandle {
     let server = HttpServerBuilder::default().build(rpc_addr).await.unwrap();
-
     let module = create_rpc_module(rpc_context);
 
     debug!("Starting RPC server at {:?}", server.local_addr().unwrap());
-    let _server_handle = server.start(module).unwrap();
+    let server_handle = server.start(module).unwrap();
 
     debug!("RPC server was successfully started");
-
-    std::future::pending::<()>().await;
+    server_handle
 }
 
 fn create_rpc_module(rpc_context: RpcContext) -> RpcModule<RpcContext> {


### PR DESCRIPTION
Implements a basic, mutually exclusive RPC server as an alternative to file logging. The server has one method, `getmetrics`, that responds with a JSON-serialized `NetworkSummary`. Also adds a two cli arguments for binding and enabling the RPC server.